### PR TITLE
Add Border support sample and tests (fixes #3)

### DIFF
--- a/samples/SwipeCardView.Sample/MainPage.xaml
+++ b/samples/SwipeCardView.Sample/MainPage.xaml
@@ -14,6 +14,7 @@
         <Button Text="Tinder Page" Clicked="OnTinderPageClicked" />
         <Button Text="Customizable Page" Clicked="OnCustomizablePageClicked" />
         <Button Text="Colors Page" Clicked="OnColorsPageClicked" />
+        <Button Text="Border Page" Clicked="OnBorderPageClicked" />
     </VerticalStackLayout>
 
 </ContentPage>

--- a/samples/SwipeCardView.Sample/MainPage.xaml.cs
+++ b/samples/SwipeCardView.Sample/MainPage.xaml.cs
@@ -28,4 +28,9 @@ public partial class MainPage : ContentPage
 	{
 		Navigation.PushAsync(new ColorsPage());
 	}
+
+	private void OnBorderPageClicked(object sender, EventArgs e)
+	{
+		Navigation.PushAsync(new BorderPage());
+	}
 }

--- a/samples/SwipeCardView.Sample/Views/BorderPage.xaml
+++ b/samples/SwipeCardView.Sample/Views/BorderPage.xaml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:swipeCardView="clr-namespace:Plugin.Maui.SwipeCardView;assembly=Plugin.Maui.SwipeCardView"
+             x:Class="SwipeCardView.Sample.Views.BorderPage"
+             Shell.BackgroundColor="{x:StaticResource Primary}"
+             Shell.TitleColor="{x:StaticResource White}"
+             Title="Border Page">
+
+    <StackLayout Padding="10">
+        <Label Text="Uses Border instead of Frame (Frame is obsolete)"
+               HorizontalOptions="Center"
+               FontSize="Small"
+               TextColor="Gray" />
+        <swipeCardView:SwipeCardView
+            ItemsSource="{Binding CardItems}"
+            SwipedCommand="{Binding SwipedCommand}"
+            VerticalOptions="FillAndExpand"
+            HorizontalOptions="FillAndExpand"
+            Threshold="100">
+            <swipeCardView:SwipeCardView.ItemTemplate>
+                <DataTemplate>
+                    <!-- Border works as DataTemplate root.
+                         Key: set StrokeShape for rounded corners and BackgroundColor for visibility. -->
+                    <Border StrokeShape="RoundRectangle 16"
+                            Stroke="{x:StaticResource Primary}"
+                            StrokeThickness="2"
+                            BackgroundColor="White"
+                            Padding="20"
+                            InputTransparent="True">
+                        <Border.Shadow>
+                            <Shadow Brush="Black" Offset="2,2" Radius="8" Opacity="0.3" />
+                        </Border.Shadow>
+                        <VerticalStackLayout HorizontalOptions="Center"
+                                             VerticalOptions="Center"
+                                             Spacing="10">
+                            <Label Text="&#x1F4CC;"
+                                   FontSize="48"
+                                   HorizontalTextAlignment="Center" />
+                            <Label Text="{Binding .}"
+                                   FontSize="32"
+                                   FontAttributes="Bold"
+                                   HorizontalTextAlignment="Center" />
+                            <Label Text="Swipe me!"
+                                   FontSize="Small"
+                                   TextColor="Gray"
+                                   HorizontalTextAlignment="Center" />
+                        </VerticalStackLayout>
+                    </Border>
+                </DataTemplate>
+            </swipeCardView:SwipeCardView.ItemTemplate>
+        </swipeCardView:SwipeCardView>
+        <Label Text="{Binding Message}" HorizontalOptions="CenterAndExpand" />
+        <StackLayout Orientation="Horizontal" HorizontalOptions="Center">
+            <Button Text="Clear Items" Command="{Binding ClearItemsCommand}" />
+            <Button Text="Add 5 Items" Command="{Binding AddItemsCommand}" />
+        </StackLayout>
+    </StackLayout>
+
+</ContentPage>

--- a/samples/SwipeCardView.Sample/Views/BorderPage.xaml
+++ b/samples/SwipeCardView.Sample/Views/BorderPage.xaml
@@ -20,8 +20,11 @@
             Threshold="100">
             <swipeCardView:SwipeCardView.ItemTemplate>
                 <DataTemplate>
-                    <!-- Border works as DataTemplate root.
-                         Key: set StrokeShape for rounded corners and BackgroundColor for visibility. -->
+                    <!-- Border works as DataTemplate root (fixes issue #3).
+                         Required properties for Border (unlike Frame):
+                         - StrokeShape: defines shape (Border has no default)
+                         - BackgroundColor: fills interior (transparent by default)
+                         - InputTransparent: allows swipe gestures to pass through -->
                     <Border StrokeShape="RoundRectangle 16"
                             Stroke="{x:StaticResource Primary}"
                             StrokeThickness="2"

--- a/samples/SwipeCardView.Sample/Views/BorderPage.xaml.cs
+++ b/samples/SwipeCardView.Sample/Views/BorderPage.xaml.cs
@@ -1,0 +1,12 @@
+using SwipeCardView.Sample.ViewModels;
+
+namespace SwipeCardView.Sample.Views;
+
+public partial class BorderPage : ContentPage
+{
+	public BorderPage()
+	{
+		InitializeComponent();
+		BindingContext = new SimplePageViewModel();
+	}
+}

--- a/src/Plugin.Maui.SwipeCardView.Tests/UnitTests.cs
+++ b/src/Plugin.Maui.SwipeCardView.Tests/UnitTests.cs
@@ -267,7 +267,8 @@ public class UnitTests : TestBase
     [TestMethod]
     public async Task BorderTemplate_ShouldWorkAsDataTemplateRoot()
     {
-        // Issue #3: Border should work as DataTemplate root, not just Frame
+        // Issue #3: Border should work as DataTemplate root, not just Frame.
+        // Tests functional behavior (binding, swiping); visual rendering verified in BorderPage sample.
         var borderTemplate = new DataTemplate(() =>
         {
             var border = new Border

--- a/src/Plugin.Maui.SwipeCardView.Tests/UnitTests.cs
+++ b/src/Plugin.Maui.SwipeCardView.Tests/UnitTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Plugin.Maui.SwipeCardView.Core;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
 
 namespace Plugin.Maui.SwipeCardView.Tests;
 
@@ -261,5 +262,57 @@ public class UnitTests : TestBase
 
         // Should not crash
         Assert.IsNotNull(swipeCardView);
+    }
+
+    [TestMethod]
+    public async Task BorderTemplate_ShouldWorkAsDataTemplateRoot()
+    {
+        // Issue #3: Border should work as DataTemplate root, not just Frame
+        var borderTemplate = new DataTemplate(() =>
+        {
+            var border = new Border
+            {
+                StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle { CornerRadius = 10 },
+                BackgroundColor = Colors.White,
+                InputTransparent = true
+            };
+            var label = new Label();
+            label.SetBinding(Label.TextProperty, ".");
+            border.Content = label;
+            return border;
+        });
+
+        var swipeCardView = new SwipeCardView { ItemTemplate = borderTemplate };
+        swipeCardView.ItemsSource = new ObservableCollection<string>() { "Card1", "Card2", "Card3" };
+
+        Assert.AreEqual("Card1", swipeCardView.TopItem);
+
+        await swipeCardView.InvokeSwipe(SwipeCardDirection.Right);
+        Assert.AreEqual("Card2", swipeCardView.TopItem);
+
+        await swipeCardView.InvokeSwipe(SwipeCardDirection.Left);
+        Assert.AreEqual("Card3", swipeCardView.TopItem);
+    }
+
+    [TestMethod]
+    public async Task VerticalStackLayoutTemplate_ShouldWorkAsDataTemplateRoot()
+    {
+        // Issue #3: StackLayout/VerticalStackLayout should work as DataTemplate root
+        var layoutTemplate = new DataTemplate(() =>
+        {
+            var layout = new VerticalStackLayout();
+            var label = new Label();
+            label.SetBinding(Label.TextProperty, ".");
+            layout.Children.Add(label);
+            return layout;
+        });
+
+        var swipeCardView = new SwipeCardView { ItemTemplate = layoutTemplate };
+        swipeCardView.ItemsSource = new ObservableCollection<string>() { "Card1", "Card2" };
+
+        Assert.AreEqual("Card1", swipeCardView.TopItem);
+
+        await swipeCardView.InvokeSwipe(SwipeCardDirection.Right);
+        Assert.AreEqual("Card2", swipeCardView.TopItem);
     }
 }


### PR DESCRIPTION
## Summary

Addresses issue #3 - Border (the modern replacement for the obsolete Frame) now works correctly as a DataTemplate root in SwipeCardView.

### Investigation

The original issue reported that Border showed a white screen when used as DataTemplate root. This was caused by the card layout bugs that were fixed in PR #6 (Scale=0.8 caching, opacity management, card reset logic). With those fixes in place, Border works correctly out of the box.

### Changes

**New sample page: BorderPage**
- Demonstrates Border as DataTemplate root with StrokeShape, Shadow, BackgroundColor
- Shows users the correct migration path from Frame to Border
- Includes descriptive header label

**Unit tests**
- BorderTemplate_ShouldWorkAsDataTemplateRoot - verifies Border works as template root with swipe operations
- VerticalStackLayoutTemplate_ShouldWorkAsDataTemplateRoot - verifies StackLayout variant (also mentioned in issue)
- All 17 tests pass (15 existing + 2 new)

### Verification

Tested on Android emulator (Pixel 7 API 36):
- Border page renders correctly with visible card, border stroke, and shadow
- Swiping works in all 4 directions (right, left, up, down)
- Card layout bounds consistent (no offset bugs)
- Card transitions smooth with proper animations

### Key Takeaway for Users

When migrating from Frame to Border, ensure you set:
- StrokeShape (Border has no default shape unlike Frame)
- BackgroundColor (Border has no default fill)
- InputTransparent=True (to allow pan gestures through)

Closes #3