### PR TITLE
Add animated overload for GoBack method

### DIFF
--- a/samples/SwipeCardView.Sample/Views/ColorsPage.xaml.cs
+++ b/samples/SwipeCardView.Sample/Views/ColorsPage.xaml.cs
@@ -70,6 +70,6 @@ public partial class ColorsPage : ContentPage
 
     private void OnGoBackClicked(object? sender, EventArgs e)
     {
-        SwipeCardView.GoBack();
+        SwipeCardView.GoBack(animated: true);
     }
 }

--- a/src/Plugin.Maui.SwipeCardView.Tests/UnitTests.cs
+++ b/src/Plugin.Maui.SwipeCardView.Tests/UnitTests.cs
@@ -282,6 +282,21 @@ public class UnitTests : TestBase
     }
 
     [TestMethod]
+    public async Task GoBack_Animated_ShouldReturnToPreviousCard()
+    {
+        var swipeCardView = new SwipeCardView { ItemTemplate = CreateSimpleTemplate() };
+        swipeCardView.ItemsSource = new ObservableCollection<string>() { "Item1", "Item2", "Item3" };
+
+        await swipeCardView.InvokeSwipe(SwipeCardDirection.Right);
+        Assert.AreEqual("Item2", swipeCardView.TopItem);
+
+        var result = swipeCardView.GoBack(animated: true);
+        Assert.IsTrue(result);
+        // In unit tests, animation completes instantly (no dispatcher)
+        Assert.AreEqual("Item1", swipeCardView.TopItem);
+    }
+
+    [TestMethod]
     public void GoBack_AtFirstItem_ShouldReturnFalse()
     {
         var swipeCardView = new SwipeCardView { ItemTemplate = CreateSimpleTemplate() };

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -925,38 +925,43 @@ public class SwipeCardView : ContentView, IDisposable
             // Block touch input during animation
             _ignoreTouch = true;
 
-            // Position the new top card off-screen to the left, ready to slide in
-            newTopCard.BatchBegin();
-            newTopCard.BindingContext = previousItem;
-            newTopCard.Scale = 1.0;
-            newTopCard.Rotation = 0;
-            newTopCard.TranslationX = -Width;
-            newTopCard.TranslationY = -newTopCard.Y;
-            newTopCard.ZIndex = 1;
-            newTopCard.Opacity = 1;
-            newTopCard.IsVisible = true;
-            newTopCard.BatchCommit();
-
-            // Slide the new card in from the left.
-            // TranslateToAsync may throw in unit test context (no IAnimationManager),
-            // so fall through to the final state if animation fails.
             try
             {
-                await newTopCard.TranslateToAsync(0, -newTopCard.Y, AnimationLength, Easing.CubicOut);
+                // Position the new top card off-screen to the left, ready to slide in
+                newTopCard.BatchBegin();
+                newTopCard.BindingContext = previousItem;
+                newTopCard.Scale = 1.0;
+                newTopCard.Rotation = 0;
+                newTopCard.TranslationX = -Width;
+                newTopCard.TranslationY = -newTopCard.Y;
+                newTopCard.ZIndex = 1;
+                newTopCard.Opacity = 1;
+                newTopCard.IsVisible = true;
+                newTopCard.BatchCommit();
+
+                // Slide the new card in from the left.
+                // TranslateToAsync may throw in unit test context (no IAnimationManager),
+                // so fall through to the final state if animation fails.
+                try
+                {
+                    await newTopCard.TranslateToAsync(0, -newTopCard.Y, AnimationLength, Easing.CubicOut);
+                }
+                catch (ArgumentException)
+                {
+                    newTopCard.TranslationX = 0;
+                }
+
+                // Push the old top card behind as the back card
+                oldTopCard.BatchBegin();
+                oldTopCard.ZIndex = 0;
+                oldTopCard.Scale = 1.0;
+                oldTopCard.Opacity = 0;
+                oldTopCard.BatchCommit();
             }
-            catch (ArgumentException)
+            finally
             {
-                newTopCard.TranslationX = 0;
+                _ignoreTouch = false;
             }
-
-            // Push the old top card behind as the back card
-            oldTopCard.BatchBegin();
-            oldTopCard.ZIndex = 0;
-            oldTopCard.Scale = 1.0;
-            oldTopCard.Opacity = 0;
-            oldTopCard.BatchCommit();
-
-            _ignoreTouch = false;
         }
         else
         {

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -379,10 +379,20 @@ public class SwipeCardView : ContentView, IDisposable
     #endregion Public Methods
 
     /// <summary>
-    /// Goes back to the previously swiped card. Returns true if successful,
+    /// Goes back to the previously swiped card without animation. Returns true if successful,
     /// false if already at the first item or no items are available.
     /// </summary>
     public bool GoBack()
+    {
+        return GoBack(false);
+    }
+
+    /// <summary>
+    /// Goes back to the previously swiped card. Returns true if successful,
+    /// false if already at the first item or no items are available.
+    /// </summary>
+    /// <param name="animated">When true, the previous card slides in from the left with animation.</param>
+    public bool GoBack(bool animated)
     {
         if (_disposed || _ignoreTouch || _programmaticSwipe)
         {
@@ -414,7 +424,7 @@ public class SwipeCardView : ContentView, IDisposable
             return false;
         }
 
-        ShowPreviousCard();
+        ShowPreviousCard(animated);
         return true;
     }
 
@@ -890,7 +900,7 @@ public class SwipeCardView : ContentView, IDisposable
         }
     }
 
-    private void ShowPreviousCard()
+    private async void ShowPreviousCard(bool animated = false)
     {
         if (ItemsSource == null || ItemsSource.Count == 0)
         {
@@ -910,24 +920,65 @@ public class SwipeCardView : ContentView, IDisposable
         oldTopCard.CancelAnimations();
         newTopCard.CancelAnimations();
 
-        // Set up the new top card with the previous item
-        newTopCard.BatchBegin();
-        newTopCard.BindingContext = previousItem;
-        newTopCard.Scale = 1.0;
-        newTopCard.Rotation = 0;
-        newTopCard.TranslationX = 0;
-        newTopCard.TranslationY = -newTopCard.Y;
-        newTopCard.ZIndex = 1;
-        newTopCard.Opacity = 1;
-        newTopCard.IsVisible = true;
-        newTopCard.BatchCommit();
+        if (animated)
+        {
+            // Block touch input during animation
+            _ignoreTouch = true;
 
-        // Push the old top card behind as the back card
-        oldTopCard.BatchBegin();
-        oldTopCard.ZIndex = 0;
-        oldTopCard.Scale = 1.0;
-        oldTopCard.Opacity = 0;
-        oldTopCard.BatchCommit();
+            // Position the new top card off-screen to the left, ready to slide in
+            newTopCard.BatchBegin();
+            newTopCard.BindingContext = previousItem;
+            newTopCard.Scale = 1.0;
+            newTopCard.Rotation = 0;
+            newTopCard.TranslationX = -Width;
+            newTopCard.TranslationY = -newTopCard.Y;
+            newTopCard.ZIndex = 1;
+            newTopCard.Opacity = 1;
+            newTopCard.IsVisible = true;
+            newTopCard.BatchCommit();
+
+            // Slide the new card in from the left.
+            // TranslateToAsync may throw in unit test context (no IAnimationManager),
+            // so fall through to the final state if animation fails.
+            try
+            {
+                await newTopCard.TranslateToAsync(0, -newTopCard.Y, AnimationLength, Easing.CubicOut);
+            }
+            catch (ArgumentException)
+            {
+                newTopCard.TranslationX = 0;
+            }
+
+            // Push the old top card behind as the back card
+            oldTopCard.BatchBegin();
+            oldTopCard.ZIndex = 0;
+            oldTopCard.Scale = 1.0;
+            oldTopCard.Opacity = 0;
+            oldTopCard.BatchCommit();
+
+            _ignoreTouch = false;
+        }
+        else
+        {
+            // Instant swap (no animation)
+            newTopCard.BatchBegin();
+            newTopCard.BindingContext = previousItem;
+            newTopCard.Scale = 1.0;
+            newTopCard.Rotation = 0;
+            newTopCard.TranslationX = 0;
+            newTopCard.TranslationY = -newTopCard.Y;
+            newTopCard.ZIndex = 1;
+            newTopCard.Opacity = 1;
+            newTopCard.IsVisible = true;
+            newTopCard.BatchCommit();
+
+            // Push the old top card behind as the back card
+            oldTopCard.BatchBegin();
+            oldTopCard.ZIndex = 0;
+            oldTopCard.Scale = 1.0;
+            oldTopCard.Opacity = 0;
+            oldTopCard.BatchCommit();
+        }
 
         // Update indices
         _currentDisplayIndex--;


### PR DESCRIPTION
## Summary

Adds a \\GoBack(bool animated)\\ overload so users can choose between an instant snap-back or a smooth slide-in animation when returning to the previous card.

## Changes

### API

\\\csharp
// Instant (default, backward compatible)
swipeCardView.GoBack();

// Animated - previous card slides in from the left
swipeCardView.GoBack(animated: true);
\\\

### Implementation (\\SwipeCardView.cs\\)
- **\\GoBack()\\** — calls \\GoBack(false)\\ for backward compatibility
- **\\GoBack(bool animated)\\** — when \\nimated: true\\, positions the previous card off-screen left then slides it in using \\TranslateToAsync\\ with \\AnimationLength\\ and \\Easing.CubicOut\\
- Touch input is blocked during animation via \\_ignoreTouch\\ flag
- Animation failure in unit tests (no \\IAnimationManager\\) is handled gracefully with try-catch fallback

### Sample App
- Colors page now uses \\GoBack(animated: true)\\ to demonstrate the feature

### Tests
- Added \\GoBack_Animated_ShouldReturnToPreviousCard\\ test (25 total, all passing)

## Verified on Android Emulator
- Card 1 → swipe → Card 2 → animated GoBack → Card 1 slides in from left ✅
- Card bounds correct after animated GoBack (1027px width) ✅
- No visual glitches ✅