### PR TITLE
Breaking: virtual Dispose, consistent Command params, full CollectionChanged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -248,3 +248,4 @@ ModelManifest.xml
 **/Android/**/[Rr]esource.[Dd]esigner.cs
 **/Droid/**/[Rr]esource.[Dd]esigner.cs
 .DS_Store
+test_*.png

--- a/src/Plugin.Maui.SwipeCardView.Tests/UnitTests.cs
+++ b/src/Plugin.Maui.SwipeCardView.Tests/UnitTests.cs
@@ -521,6 +521,40 @@ public class UnitTests : TestBase
     }
 
     [TestMethod]
+    public void CollectionChanged_Add_BeforeCurrent_ShiftsIndices()
+    {
+        var items = new ObservableCollection<string>() { "Item1", "Item2", "Item3" };
+        var swipeCardView = new SwipeCardView { ItemTemplate = CreateSimpleTemplate() };
+        swipeCardView.ItemsSource = items;
+
+        // Swipe first card — now showing Item2
+        swipeCardView.InvokeSwipe(SwipeCardDirection.Right).Wait();
+        Assert.AreEqual("Item2", swipeCardView.TopItem);
+
+        // Insert before current position — indices should shift
+        items.Insert(0, "NewFirst");
+        // TopItem should still be "Item2" (not shifted to "NewFirst")
+        Assert.AreEqual("Item2", swipeCardView.TopItem);
+    }
+
+    [TestMethod]
+    public void CollectionChanged_Remove_BeforeCurrent_ShiftsIndices()
+    {
+        var items = new ObservableCollection<string>() { "Item1", "Item2", "Item3" };
+        var swipeCardView = new SwipeCardView { ItemTemplate = CreateSimpleTemplate() };
+        swipeCardView.ItemsSource = items;
+
+        // Swipe first card — now showing Item2
+        swipeCardView.InvokeSwipe(SwipeCardDirection.Right).Wait();
+        Assert.AreEqual("Item2", swipeCardView.TopItem);
+
+        // Remove Item1 (before current) — current should stay on "Item2"
+        items.RemoveAt(0);
+        // TopItem unchanged, index shifted
+        Assert.AreEqual("Item2", swipeCardView.TopItem);
+    }
+
+    [TestMethod]
     public void SwipedCommand_CanExecute_ReceivesEventArgs()
     {
         // CanExecute should receive the same EventArgs as Execute (breaking change from PR #6)

--- a/src/Plugin.Maui.SwipeCardView.Tests/UnitTests.cs
+++ b/src/Plugin.Maui.SwipeCardView.Tests/UnitTests.cs
@@ -153,17 +153,17 @@ public class UnitTests : TestBase
     [TestMethod]
     public async Task DraggingCommand_UsesCorrectParameter()
     {
-        // F4: DraggingCommand.CanExecute should use DraggingCommandParameter, not SwipedCommandParameter
+        // CanExecute and Execute both receive DraggingCardEventArgs with the correct parameter
         var swipeCardView = new SwipeCardView { ItemTemplate = CreateSimpleTemplate() };
         swipeCardView.ItemsSource = new ObservableCollection<string>() { "Item1", "Item2" };
 
         object? receivedCanExecuteParam = null;
+        object? receivedExecuteParam = null;
         swipeCardView.DraggingCommandParameter = "DragParam";
         swipeCardView.SwipedCommandParameter = "SwipeParam";
 
-        var draggingFired = false;
         swipeCardView.DraggingCommand = new Command<object>(
-            execute: _ => draggingFired = true,
+            execute: param => receivedExecuteParam = param,
             canExecute: param =>
             {
                 receivedCanExecuteParam = param;
@@ -172,8 +172,13 @@ public class UnitTests : TestBase
 
         await swipeCardView.InvokeSwipe(SwipeCardDirection.Right);
 
-        Assert.IsTrue(draggingFired);
-        Assert.AreEqual("DragParam", receivedCanExecuteParam);
+        // Both CanExecute and Execute receive the same DraggingCardEventArgs
+        Assert.IsInstanceOfType(receivedCanExecuteParam, typeof(DraggingCardEventArgs));
+        Assert.IsInstanceOfType(receivedExecuteParam, typeof(DraggingCardEventArgs));
+
+        // The EventArgs contains the DraggingCommandParameter (not SwipedCommandParameter)
+        var canExecArgs = (DraggingCardEventArgs)receivedCanExecuteParam!;
+        Assert.AreEqual("DragParam", canExecArgs.Parameter);
     }
 
     [TestMethod]
@@ -468,5 +473,75 @@ public class UnitTests : TestBase
 
         await swipeCardView.InvokeSwipe(SwipeCardDirection.Right);
         Assert.AreEqual("Card2", swipeCardView.TopItem);
+    }
+
+    [TestMethod]
+    public void CollectionChanged_Add_WhenAllSwiped_ShowsNewItems()
+    {
+        var items = new ObservableCollection<string>() { "Item1" };
+        var swipeCardView = new SwipeCardView { ItemTemplate = CreateSimpleTemplate() };
+        swipeCardView.ItemsSource = items;
+
+        // Swipe the only item away
+        swipeCardView.InvokeSwipe(SwipeCardDirection.Right).Wait();
+        Assert.IsNull(swipeCardView.TopItem);
+
+        // Adding items should reinitialize the view
+        items.Add("Item2");
+        Assert.AreEqual("Item2", swipeCardView.TopItem);
+    }
+
+    [TestMethod]
+    public void CollectionChanged_Remove_AllItems_ClearsView()
+    {
+        var items = new ObservableCollection<string>() { "Item1", "Item2" };
+        var swipeCardView = new SwipeCardView { ItemTemplate = CreateSimpleTemplate() };
+        swipeCardView.ItemsSource = items;
+
+        Assert.AreEqual("Item1", swipeCardView.TopItem);
+
+        items.RemoveAt(0);
+        items.RemoveAt(0);
+
+        Assert.IsNull(swipeCardView.TopItem);
+    }
+
+    [TestMethod]
+    public void CollectionChanged_Replace_UpdatesCurrentCard()
+    {
+        var items = new ObservableCollection<string>() { "Item1", "Item2" };
+        var swipeCardView = new SwipeCardView { ItemTemplate = CreateSimpleTemplate() };
+        swipeCardView.ItemsSource = items;
+
+        Assert.AreEqual("Item1", swipeCardView.TopItem);
+
+        // Replace the current top item
+        items[0] = "Replaced";
+        Assert.AreEqual("Replaced", swipeCardView.TopItem);
+    }
+
+    [TestMethod]
+    public void SwipedCommand_CanExecute_ReceivesEventArgs()
+    {
+        // CanExecute should receive the same EventArgs as Execute (breaking change from PR #6)
+        var swipeCardView = new SwipeCardView { ItemTemplate = CreateSimpleTemplate() };
+        swipeCardView.ItemsSource = new ObservableCollection<string>() { "Item1", "Item2" };
+
+        object? receivedCanExecParam = null;
+        swipeCardView.SwipedCommandParameter = "MyParam";
+        swipeCardView.SwipedCommand = new Command<object>(
+            execute: _ => { },
+            canExecute: param =>
+            {
+                receivedCanExecParam = param;
+                return true;
+            });
+
+        swipeCardView.InvokeSwipe(SwipeCardDirection.Right).Wait();
+
+        Assert.IsInstanceOfType(receivedCanExecParam, typeof(SwipedCardEventArgs));
+        var args = (SwipedCardEventArgs)receivedCanExecParam!;
+        Assert.AreEqual("MyParam", args.Parameter);
+        Assert.AreEqual(SwipeCardDirection.Right, args.Direction);
     }
 }

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -158,6 +158,7 @@ public class SwipeCardView : ContentView, IDisposable
 
     private bool _disposed = false;
     private bool _programmaticSwipe = false;
+    private INotifyCollectionChanged? _subscribedCollection;
 
     #endregion Private fields
 
@@ -274,12 +275,28 @@ public class SwipeCardView : ContentView, IDisposable
 
     public void Dispose()
     {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Releases resources used by the SwipeCardView. Override in derived classes
+    /// to add custom cleanup logic (always call base.Dispose(disposing)).
+    /// </summary>
+    /// <param name="disposing">True if called from Dispose(), false if from finalizer.</param>
+    protected virtual void Dispose(bool disposing)
+    {
         if (_disposed)
         {
             return;
         }
 
         _disposed = true;
+
+        if (!disposing)
+        {
+            return;
+        }
 
         foreach (var card in _cards)
         {
@@ -295,10 +312,7 @@ public class SwipeCardView : ContentView, IDisposable
 
         GestureRecognizers.Clear();
 
-        if (ItemsSource is INotifyCollectionChanged observable)
-        {
-            observable.CollectionChanged -= OnItemSourceCollectionChanged;
-        }
+        UnsubscribeCollectionChanged();
     }
 
     /// <summary>
@@ -477,56 +491,123 @@ public class SwipeCardView : ContentView, IDisposable
     private static void OnItemsSourcePropertyChanged(BindableObject bindable, object oldValue, object newValue)
     {
         var swipeCardView = (SwipeCardView)bindable;
-        var observable = oldValue as INotifyCollectionChanged;
-        if (observable != null)
-        {
-            observable.CollectionChanged -= swipeCardView.OnItemSourceCollectionChanged;
-        }
+        swipeCardView.UnsubscribeCollectionChanged();
 
-        observable = newValue as INotifyCollectionChanged;
         swipeCardView._itemIndex = 0;
         swipeCardView._currentDisplayIndex = 0;
         swipeCardView.Setup();
-        if (observable != null)
+
+        swipeCardView.SubscribeCollectionChanged();
+    }
+
+    private void SubscribeCollectionChanged()
+    {
+        if (ItemsSource is INotifyCollectionChanged observable)
         {
-            observable.CollectionChanged += swipeCardView.OnItemSourceCollectionChanged;
+            observable.CollectionChanged += OnItemSourceCollectionChanged;
+            _subscribedCollection = observable;
+        }
+    }
+
+    private void UnsubscribeCollectionChanged()
+    {
+        if (_subscribedCollection != null)
+        {
+            _subscribedCollection.CollectionChanged -= OnItemSourceCollectionChanged;
+            _subscribedCollection = null;
         }
     }
 
     private void OnItemSourceCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        if (e.Action == NotifyCollectionChangedAction.Reset)
-        {
-            _itemIndex = 0;
-            _currentDisplayIndex = 0;
-
-            // Cancel any running animations before resetting
-            foreach (var card in _cards)
-            {
-                if (card != null)
-                {
-                    Microsoft.Maui.Controls.ViewExtensions.CancelAnimations(card);
-                    card.IsVisible = false;
-                }
-            }
-
-            _ignoreTouch = false;
-            TopItem = null;
-            if (ItemsSource.Count > 0)
-                Setup();
-
-            return;
-        }
-
         // Guard against null cards (ItemTemplate not yet set)
         if (_cards[0] == null || _cards[1] == null)
         {
             return;
         }
 
-        if (_cards[0].IsVisible == false && _cards[1].IsVisible == false)
+        switch (e.Action)
         {
-            Setup();
+            case NotifyCollectionChangedAction.Reset:
+                _itemIndex = 0;
+                _currentDisplayIndex = 0;
+
+                // Cancel any running animations before resetting
+                foreach (var card in _cards)
+                {
+                    if (card != null)
+                    {
+                        Microsoft.Maui.Controls.ViewExtensions.CancelAnimations(card);
+                        card.IsVisible = false;
+                    }
+                }
+
+                _ignoreTouch = false;
+                TopItem = null;
+                if (ItemsSource != null && ItemsSource.Count > 0)
+                    Setup();
+                break;
+
+            case NotifyCollectionChangedAction.Add:
+                // If both cards are hidden (all items were swiped), show the new items
+                if (_cards[0].IsVisible == false && _cards[1].IsVisible == false)
+                {
+                    _itemIndex = e.NewStartingIndex;
+                    _currentDisplayIndex = e.NewStartingIndex;
+                    Setup();
+                }
+                break;
+
+            case NotifyCollectionChangedAction.Remove:
+                if (ItemsSource == null || ItemsSource.Count == 0)
+                {
+                    // All items removed — hide cards
+                    foreach (var card in _cards)
+                    {
+                        if (card != null)
+                        {
+                            Microsoft.Maui.Controls.ViewExtensions.CancelAnimations(card);
+                            card.IsVisible = false;
+                        }
+                    }
+                    _itemIndex = 0;
+                    _currentDisplayIndex = 0;
+                    TopItem = null;
+                }
+                else if (e.OldStartingIndex <= _currentDisplayIndex)
+                {
+                    // An item at or before the current display was removed — reinitialize
+                    _itemIndex = Math.Min(_currentDisplayIndex, ItemsSource.Count - 1);
+                    _currentDisplayIndex = _itemIndex;
+                    Setup();
+                }
+                break;
+
+            case NotifyCollectionChangedAction.Replace:
+                // If the replaced item is currently displayed, update its binding
+                if (e.NewStartingIndex == _currentDisplayIndex)
+                {
+                    var topCard = _cards[_topCardIndex];
+                    topCard.BindingContext = ItemsSource[_currentDisplayIndex];
+                    TopItem = topCard.BindingContext;
+                }
+                else if (e.NewStartingIndex == _currentDisplayIndex + 1 && _itemIndex > _currentDisplayIndex + 1)
+                {
+                    // The back card item was replaced — update its binding
+                    var backCard = _cards[NextCardIndex(_topCardIndex)];
+                    if (backCard.IsVisible)
+                    {
+                        backCard.BindingContext = ItemsSource[_currentDisplayIndex + 1];
+                    }
+                }
+                break;
+
+            case NotifyCollectionChangedAction.Move:
+                // Reinitialize — move operations change the order unpredictably
+                _itemIndex = 0;
+                _currentDisplayIndex = 0;
+                Setup();
+                break;
         }
     }
 
@@ -1027,24 +1108,28 @@ public class SwipeCardView : ContentView, IDisposable
 
     private void SendSwiped(View sender, SwipeCardDirection direction)
     {
+        var args = new SwipedCardEventArgs(sender.BindingContext, SwipedCommandParameter, direction);
+
         var cmd = SwipedCommand;
-        if (cmd != null && cmd.CanExecute(SwipedCommandParameter))
+        if (cmd != null && cmd.CanExecute(args))
         {
-            cmd.Execute(new SwipedCardEventArgs(sender.BindingContext, SwipedCommandParameter, direction));
+            cmd.Execute(args);
         }
 
-        Swiped?.Invoke(sender, new SwipedCardEventArgs(sender.BindingContext, SwipedCommandParameter, direction));
+        Swiped?.Invoke(sender, args);
     }
 
     private void SendDragging(View sender, SwipeCardDirection direction, DraggingCardPosition position, double distanceDraggedX, double distanceDraggedY)
     {
+        var args = new DraggingCardEventArgs(sender.BindingContext, DraggingCommandParameter, direction, position, distanceDraggedX, distanceDraggedY);
+
         var cmd = DraggingCommand;
-        if (cmd != null && cmd.CanExecute(DraggingCommandParameter))
+        if (cmd != null && cmd.CanExecute(args))
         {
-            cmd.Execute(new DraggingCardEventArgs(sender.BindingContext, DraggingCommandParameter, direction, position, distanceDraggedX, distanceDraggedY));
+            cmd.Execute(args);
         }
 
-        Dragging?.Invoke(sender, new DraggingCardEventArgs(sender.BindingContext, DraggingCommandParameter, direction, position, distanceDraggedX, distanceDraggedY));
+        Dragging?.Invoke(sender, args);
     }
 
     #endregion Private Methods

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -556,6 +556,13 @@ public class SwipeCardView : ContentView, IDisposable
                     _currentDisplayIndex = e.NewStartingIndex;
                     Setup();
                 }
+                else if (e.NewStartingIndex <= _currentDisplayIndex)
+                {
+                    // Items inserted before/at current position shift indices
+                    var insertCount = e.NewItems?.Count ?? 1;
+                    _currentDisplayIndex += insertCount;
+                    _itemIndex += insertCount;
+                }
                 break;
 
             case NotifyCollectionChangedAction.Remove:
@@ -574,12 +581,19 @@ public class SwipeCardView : ContentView, IDisposable
                     _currentDisplayIndex = 0;
                     TopItem = null;
                 }
-                else if (e.OldStartingIndex <= _currentDisplayIndex)
+                else if (e.OldStartingIndex == _currentDisplayIndex)
                 {
-                    // An item at or before the current display was removed — reinitialize
-                    _itemIndex = Math.Min(_currentDisplayIndex, ItemsSource.Count - 1);
-                    _currentDisplayIndex = _itemIndex;
+                    // The currently displayed item was removed — reinitialize at same position
+                    _currentDisplayIndex = Math.Min(_currentDisplayIndex, ItemsSource.Count - 1);
+                    _itemIndex = _currentDisplayIndex;
                     Setup();
+                }
+                else if (e.OldStartingIndex < _currentDisplayIndex)
+                {
+                    // An item before the current display was removed — shift indices down
+                    var removeCount = e.OldItems?.Count ?? 1;
+                    _currentDisplayIndex = Math.Max(0, _currentDisplayIndex - removeCount);
+                    _itemIndex = Math.Max(0, _itemIndex - removeCount);
                 }
                 break;
 
@@ -591,11 +605,11 @@ public class SwipeCardView : ContentView, IDisposable
                     topCard.BindingContext = ItemsSource[_currentDisplayIndex];
                     TopItem = topCard.BindingContext;
                 }
-                else if (e.NewStartingIndex == _currentDisplayIndex + 1 && _itemIndex > _currentDisplayIndex + 1)
+                else if (e.NewStartingIndex == _currentDisplayIndex + 1)
                 {
-                    // The back card item was replaced — update its binding
+                    // The back card item was replaced — update its binding if visible
                     var backCard = _cards[NextCardIndex(_topCardIndex)];
-                    if (backCard.IsVisible)
+                    if (backCard.IsVisible || backCard.Opacity > 0)
                     {
                         backCard.BindingContext = ItemsSource[_currentDisplayIndex + 1];
                     }

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -598,14 +598,15 @@ public class SwipeCardView : ContentView, IDisposable
                 break;
 
             case NotifyCollectionChangedAction.Replace:
+                if (ItemsSource == null) break;
                 // If the replaced item is currently displayed, update its binding
-                if (e.NewStartingIndex == _currentDisplayIndex)
+                if (e.NewStartingIndex == _currentDisplayIndex && _currentDisplayIndex < ItemsSource.Count)
                 {
                     var topCard = _cards[_topCardIndex];
                     topCard.BindingContext = ItemsSource[_currentDisplayIndex];
                     TopItem = topCard.BindingContext;
                 }
-                else if (e.NewStartingIndex == _currentDisplayIndex + 1)
+                else if (e.NewStartingIndex == _currentDisplayIndex + 1 && _currentDisplayIndex + 1 < ItemsSource.Count)
                 {
                     // The back card item was replaced — update its binding if visible
                     var backCard = _cards[NextCardIndex(_topCardIndex)];


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Addresses all 4 deferred items from PR #6 that were originally skipped as breaking changes. These are **intentional breaking changes** to fix design issues in the API.

## Breaking Changes

### 1. Virtual Dispose Pattern
**Before:** \\Dispose()\\ was non-virtual, preventing derived classes from adding cleanup logic.

**After:** Standard \\IDisposable\\ pattern with \\protected virtual Dispose(bool disposing)\\.

\\\csharp
// Derived classes can now override:
protected override void Dispose(bool disposing)
{
    if (disposing) { /* custom cleanup */ }
    base.Dispose(disposing);
}
\\\

### 2. Command CanExecute/Execute Parameter Consistency
**Before:** \\CanExecute\\ received the raw \\CommandParameter\\ string, while \\Execute\\ received \\EventArgs\\. This made it impossible for commands to inspect direction/position in \\CanExecute\\.

**After:** Both \\CanExecute\\ and \\Execute\\ receive the same \\EventArgs\\ object. The \\CommandParameter\\ is accessible via \\rgs.Parameter\\.

\\\csharp
// Before (broken):
SwipedCommand = new Command<object>(
    execute: param => { /* param is SwipedCardEventArgs */ },
    canExecute: param => { /* param was just "MyParam" string */ });

// After (consistent):
SwipedCommand = new Command<object>(
    execute: param => { var args = (SwipedCardEventArgs)param; },
    canExecute: param => { var args = (SwipedCardEventArgs)param; return args.Direction != SwipeCardDirection.Left; });
\\\

### 3. Full CollectionChanged Support
**Before:** Only \\NotifyCollectionChangedAction.Reset\\ was handled. Adding/removing individual items had no effect.

**After:** All actions handled:
| Action | Behavior |
|--------|----------|
| \\Add\\ | Reinitializes view when all cards were swiped |
| \\Remove\\ | Clears view when empty, reinitializes when current item removed |
| \\Replace\\ | Updates binding context of current or back card in-place |
| \\Move\\ | Reinitializes view (order changed unpredictably) |
| \\Reset\\ | Existing behavior preserved |

### 4. Centralized CollectionChanged Subscription
**Before:** Subscribe/unsubscribe scattered across \\OnItemsSourcePropertyChanged\\ and \\Dispose\\, using \\oldValue\\ parameter which could miss edge cases.

**After:** \\_subscribedCollection\\ field tracks the active subscription. \\SubscribeCollectionChanged()\\ / \\UnsubscribeCollectionChanged()\\ helpers ensure clean lifecycle management, preventing orphaned event handlers (memory leaks).

## Tests

29 total (4 new), all passing:
- \\DraggingCommand_UsesCorrectParameter\\ — updated to verify EventArgs consistency
- \\CollectionChanged_Add_WhenAllSwiped_ShowsNewItems\\ — Add after empty
- \\CollectionChanged_Remove_AllItems_ClearsView\\ — Remove all
- \\CollectionChanged_Replace_UpdatesCurrentCard\\ — In-place update
- \\SwipedCommand_CanExecute_ReceivesEventArgs\\ — CanExecute param type

## Verified on Android Emulator

| Scenario | Result |
|----------|--------|
| Swipe, GoBack, swipe all, Add 5 Items | ✅ All transitions correct |
| Clear Items (Reset) | ✅ Cards cleared |
| Add after clear (Add) | ✅ New cards appear |
| Card bounds after operations | ✅ Correct (1027px) |