### PR TITLE
Fix Android layout cache corruption from BackCardScale animation

### DIFF
--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -871,6 +871,7 @@ public class SwipeCardView : ContentView, IDisposable
                 var backCard = _cards[NextCardIndex(_topCardIndex)];
                 backCard.CancelAnimations();
                 backCard.Scale = 1.0;
+                InvalidateCardLayout(backCard);
 
                 // State transition must happen regardless of animation success
                 topCard.IsVisible = false;
@@ -884,20 +885,25 @@ public class SwipeCardView : ContentView, IDisposable
             }
             else
             {
-                // Snap-back animations (best-effort)
+                // Hide the back card immediately and reset its Scale to 1.0
+                // BEFORE the snap-back animation. Animating Scale to BackCardScale
+                // (0.8) can corrupt Android's native layout cache, causing the card
+                // to render at 80% size even after Scale is restored to 1.0.
+                var prevCard = _cards[PrevCardIndex(_topCardIndex)];
+                prevCard.CancelAnimations();
+                prevCard.Opacity = 0;
+                prevCard.Scale = 1.0;
+
+                // Snap-back animations for the top card only (best-effort)
                 try
                 {
-                    // Cancel any lingering animations before starting snap-back
                     topCard.CancelAnimations();
-                    var prevCard = _cards[PrevCardIndex(_topCardIndex)];
-                    prevCard.CancelAnimations();
 
                     // Snap-back: TranslationX must animate to 0 (matching Setup home position)
                     var translateTask = topCard.TranslateToAsync(0, -topCard.Y, AnimationLength, Easing.SpringOut);
                     var rotateTask = topCard.RotateToAsync(0, AnimationLength, Easing.SpringOut);
-                    var scaleTask = prevCard.ScaleToAsync(BackCardScale, AnimationLength, Easing.SpringOut);
 
-                    await Task.WhenAll(translateTask, rotateTask, scaleTask);
+                    await Task.WhenAll(translateTask, rotateTask);
                 }
                 catch (Exception ex)
                 {
@@ -908,10 +914,8 @@ public class SwipeCardView : ContentView, IDisposable
                 topCard.Scale = 1.0;
                 topCard.TranslationX = 0;
 
-                // Hide back card again and reset Scale to 1.0 for correct layout
-                var snapBackCard = _cards[PrevCardIndex(_topCardIndex)];
-                snapBackCard.Opacity = 0;
-                snapBackCard.Scale = 1.0;
+                // Force layout invalidation to clear any stale Android layout cache
+                InvalidateCardLayout(prevCard);
             }
         }
         catch (Exception ex)
@@ -954,22 +958,9 @@ public class SwipeCardView : ContentView, IDisposable
         newTopCard.Opacity = 1;
         newTopCard.BatchCommit();
 
-        // Schedule a deferred layout invalidation after the current layout cycle.
-        // This forces Android to re-measure the card at Scale=1.0, which is needed
-        // when inner content was modified during the drag (e.g. label text changes)
-        // while the card was at BackCardScale, causing the CardView to cache stale bounds.
-        try
-        {
-            Dispatcher.Dispatch(() =>
-            {
-                newTopCard.InvalidateMeasure();
-                ((View)newTopCard.Parent)?.InvalidateMeasure();
-            });
-        }
-        catch (InvalidOperationException)
-        {
-            // No dispatcher available (e.g. unit test context) — skip layout invalidation
-        }
+        // Force layout invalidation to clear any stale Android layout cache
+        // from when the card was at BackCardScale during the drag.
+        InvalidateCardLayout(newTopCard);
 
         // If there are more cards to show, recycle the old top card
         // for the next item in the source
@@ -1119,6 +1110,25 @@ public class SwipeCardView : ContentView, IDisposable
     private float GetScale(int index)
     {
         return index == _topCardIndex ? 1.0f : BackCardScale;
+    }
+
+    /// <summary>
+    /// Forces a layout invalidation on a card to clear any stale Android layout cache.
+    /// Android's native CardView can cache layout bounds computed while the card was
+    /// at a non-1.0 Scale (e.g. BackCardScale=0.8 during drag). This method ensures
+    /// Android re-measures the card at its current Scale.
+    /// </summary>
+    private void InvalidateCardLayout(View card)
+    {
+        try
+        {
+            card.InvalidateMeasure();
+            ((View?)card.Parent)?.InvalidateMeasure();
+        }
+        catch (Exception)
+        {
+            // Ignore — may fail in unit test context without a renderer
+        }
     }
 
     private void SendSwiped(View sender, SwipeCardDirection direction)


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Problem

After certain swipe sequences (especially swipe → partial drag → swipe), the top card could render at ~80% size and shifted to the upper-left corner, with the back card visible at full size behind it.

## Root Cause

The snap-back path in \\HandleTouchEnd\\ animated the back card's Scale **down to BackCardScale (0.8)** via \\ScaleToAsync\\. During this animation, Android's native layout system could cache the card's measured bounds at 80% size. When the card later became the top card at Scale=1.0, the stale cached bounds caused it to render smaller and offset.

Additionally, the \\InvalidateMeasure\\ in \\ShowNextCard\\ was deferred via \\Dispatcher.Dispatch\\, which could run too late to prevent a frame with stale bounds.

## Fix

1. **Remove ScaleToAsync(BackCardScale) from snap-back** — The back card is now hidden immediately with \\Opacity=0\\ and \\Scale=1.0\\ instead of being animated to 0.8 scale first. The user never sees this card during snap-back anyway.

2. **Add \\InvalidateCardLayout()\\ helper** — Centralized method that calls \\InvalidateMeasure()\\ on the card and its parent to force Android to re-measure at the current Scale.

3. **Call InvalidateCardLayout synchronously** — Replaced the deferred \\Dispatcher.Dispatch\\ with a synchronous call after setting Scale=1.0 in both \\ShowNextCard\\ and \\HandleTouchEnd\\.

## Verified

All 31 tests pass. Tested extensively on Android emulator:
- Swipe → snap-back → swipe ✅
- Rapid partial drags ✅ 
- GoBack (animated) ✅
- Clear Items → Add 5 Items → swipe ✅
- All cards render at full size in every scenario