### PR TITLE
Restore snap-back scale animation

### DIFF
--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -885,25 +885,21 @@ public class SwipeCardView : ContentView, IDisposable
             }
             else
             {
-                // Hide the back card immediately and reset its Scale to 1.0
-                // BEFORE the snap-back animation. Animating Scale to BackCardScale
-                // (0.8) can corrupt Android's native layout cache, causing the card
-                // to render at 80% size even after Scale is restored to 1.0.
                 var prevCard = _cards[PrevCardIndex(_topCardIndex)];
                 prevCard.CancelAnimations();
-                prevCard.Opacity = 0;
-                prevCard.Scale = 1.0;
 
-                // Snap-back animations for the top card only (best-effort)
+                // Snap-back animations (best-effort)
                 try
                 {
                     topCard.CancelAnimations();
 
-                    // Snap-back: TranslationX must animate to 0 (matching Setup home position)
+                    // Animate top card back to home position
                     var translateTask = topCard.TranslateToAsync(0, -topCard.Y, AnimationLength, Easing.SpringOut);
                     var rotateTask = topCard.RotateToAsync(0, AnimationLength, Easing.SpringOut);
+                    // Animate back card scale down (the nice parallax shrink effect)
+                    var scaleTask = prevCard.ScaleToAsync(BackCardScale, AnimationLength, Easing.SpringOut);
 
-                    await Task.WhenAll(translateTask, rotateTask);
+                    await Task.WhenAll(translateTask, rotateTask, scaleTask);
                 }
                 catch (Exception ex)
                 {
@@ -914,7 +910,13 @@ public class SwipeCardView : ContentView, IDisposable
                 topCard.Scale = 1.0;
                 topCard.TranslationX = 0;
 
-                // Force layout invalidation to clear any stale Android layout cache
+                // After the visible animation completes, reset the back card to
+                // Scale=1.0 and hide it. This prevents Android's native layout
+                // system from caching bounds at the smaller BackCardScale, which
+                // would cause the card to render at 80% size when it next becomes
+                // the top card.
+                prevCard.Opacity = 0;
+                prevCard.Scale = 1.0;
                 InvalidateCardLayout(prevCard);
             }
         }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Problem

PR #12 fixed the Android layout cache corruption by removing the back card's `ScaleToAsync(BackCardScale)` animation entirely during snap-back. This fixed the glitch but lost the nice parallax shrink effect where the back card visually scales down when a drag is released.

## Fix

Restore the animation by running it **then** resetting Scale immediately after:

1. Animate `prevCard.ScaleToAsync(BackCardScale)` alongside the top card snap-back (the nice visual)
2. **After** the animation completes, set `prevCard.Scale = 1.0` and `prevCard.Opacity = 0`
3. Call `InvalidateCardLayout(prevCard)` to clear Android's layout cache

The user sees the smooth scale-down animation. But by the time Android could cache the bounds, the card is already back at Scale=1.0 and hidden — so no stale layout data persists.

## Verified

- 31 tests pass
- Tested on Android emulator: swipe, partial drag snap-back, GoBack, stress sequences — all cards render at full size, no visual glitches