### PR TITLE
Fix back card not visible after Clear+Add or exhausted stack

### DIFF
--- a/src/Plugin.Maui.SwipeCardView.Tests/UnitTests.cs
+++ b/src/Plugin.Maui.SwipeCardView.Tests/UnitTests.cs
@@ -555,6 +555,49 @@ public class UnitTests : TestBase
     }
 
     [TestMethod]
+    public void CollectionChanged_Add_PreparesBackCard_WhenOnlyTopCardVisible()
+    {
+        // When Setup runs with 1 item, only card[0] is initialized.
+        // Adding a 2nd item should prepare card[1] as the back card.
+        var items = new ObservableCollection<string>() { "Item1" };
+        var swipeCardView = new SwipeCardView { ItemTemplate = CreateSimpleTemplate() };
+        swipeCardView.ItemsSource = items;
+
+        Assert.AreEqual("Item1", swipeCardView.TopItem);
+
+        // Add a second item — back card should now be ready
+        items.Add("Item2");
+
+        // Swipe — should transition to Item2
+        swipeCardView.InvokeSwipe(SwipeCardDirection.Right).Wait();
+        Assert.AreEqual("Item2", swipeCardView.TopItem);
+    }
+
+    [TestMethod]
+    public void CollectionChanged_Add_AfterClear_PreparesBackCard()
+    {
+        // Clear + Add: the first Add triggers Setup with 1 item,
+        // the second Add should prepare the back card.
+        var items = new ObservableCollection<string>() { "A", "B", "C" };
+        var swipeCardView = new SwipeCardView { ItemTemplate = CreateSimpleTemplate() };
+        swipeCardView.ItemsSource = items;
+
+        items.Clear();
+        Assert.IsNull(swipeCardView.TopItem);
+
+        // Add items back one at a time
+        items.Add("X1");
+        Assert.AreEqual("X1", swipeCardView.TopItem);
+
+        items.Add("X2");
+        items.Add("X3");
+
+        // Swipe — back card should have been prepared with X2
+        swipeCardView.InvokeSwipe(SwipeCardDirection.Right).Wait();
+        Assert.AreEqual("X2", swipeCardView.TopItem);
+    }
+
+    [TestMethod]
     public void SwipedCommand_CanExecute_ReceivesEventArgs()
     {
         // CanExecute should receive the same EventArgs as Execute (breaking change from PR #6)

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -563,6 +563,24 @@ public class SwipeCardView : ContentView, IDisposable
                     _currentDisplayIndex += insertCount;
                     _itemIndex += insertCount;
                 }
+
+                // Prepare the back card if it hasn't been initialized yet.
+                // This happens when Setup() ran with only 1 item available (e.g.,
+                // after Clear + Add, or exhausting the stack then adding new items).
+                var addBackIdx = NextCardIndex(_topCardIndex);
+                if (_cards[addBackIdx] != null && !_cards[addBackIdx].IsVisible && _itemIndex < ItemsSource.Count)
+                {
+                    var backCard = _cards[addBackIdx];
+                    backCard.BindingContext = ItemsSource[_itemIndex];
+                    backCard.Scale = 1.0;
+                    backCard.Rotation = 0;
+                    backCard.TranslationX = 0;
+                    backCard.TranslationY = -backCard.Y;
+                    backCard.ZIndex = 0;
+                    backCard.Opacity = 0;
+                    backCard.IsVisible = true;
+                    _itemIndex++;
+                }
                 break;
 
             case NotifyCollectionChangedAction.Remove:


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Problem

After clearing items and adding new ones (or swiping through all cards then adding more), the first swipe drag showed no back card behind the top card. From the second swipe onward, the back card appeared correctly.

## Root Cause

This is a **control bug**. When \\Setup()\\ runs with only 1 item available (which happens when items are added one-by-one via ObservableCollection.Add), only \\card[0]\\ is initialized — \\card[1]\\ stays \\IsVisible=false\\. When subsequent items are added, the \\CollectionChanged.Add\\ handler's \"both invisible\" check fails (card[0] is visible), and no other branch prepares the back card.

During the first drag, \\HandleTouchStart\\ sets the back card's \\Opacity=1\\, but since \\IsVisible=false\\, it never renders.

## Fix

After every Add event, check if the back card is still uninitialized (\\IsVisible=false\\). If there are unloaded items available, prepare it with the correct BindingContext, Scale=1.0, Opacity=0, IsVisible=true. This ensures the back card is always ready to be revealed when the user starts dragging.

## Tests

Added 2 new tests (33 total, all passing):
- \\CollectionChanged_Add_PreparesBackCard_WhenOnlyTopCardVisible\\ — verifies adding a 2nd item prepares the back card
- \\CollectionChanged_Add_AfterClear_PreparesBackCard\\ — verifies Clear + Add cycle works

## Verified

Tested on Android emulator with slow drag after Clear + Add 5 Items — back card (Card 2) is now visible behind Card 1 during the drag.