### PR TITLE
v1.0.0 release readiness: critical fixes from multi-model review

### DIFF
--- a/samples/SwipeCardView.Sample/Views/TinderPage.xaml.cs
+++ b/samples/SwipeCardView.Sample/Views/TinderPage.xaml.cs
@@ -13,28 +13,30 @@ public partial class TinderPage : ContentPage
         SwipeCardView.Dragging += OnDragging;
     }
 
-    private void OnDislikeClicked(object sender, EventArgs e)
+    private async void OnDislikeClicked(object sender, EventArgs e)
     {
-        SwipeCardView.InvokeSwipe(SwipeCardDirection.Left);
+        await SwipeCardView.InvokeSwipe(SwipeCardDirection.Left);
     }
 
-    private void OnSuperLikeClicked(object sender, EventArgs e)
+    private async void OnSuperLikeClicked(object sender, EventArgs e)
     {
-        SwipeCardView.InvokeSwipe(SwipeCardDirection.Up);
+        await SwipeCardView.InvokeSwipe(SwipeCardDirection.Up);
     }
 
-    private void OnLikeClicked(object sender, EventArgs e)
+    private async void OnLikeClicked(object sender, EventArgs e)
     {
-        SwipeCardView.InvokeSwipe(SwipeCardDirection.Right);
+        await SwipeCardView.InvokeSwipe(SwipeCardDirection.Right);
     }
 
     private void OnDragging(object sender, DraggingCardEventArgs e)
     {
-        var view = (View)sender;
+        if (e.CardView == null) return;
+
+        var view = e.CardView;
         var nopeFrame = view.FindByName<Frame>("NopeFrame");
         var likeFrame = view.FindByName<Frame>("LikeFrame");
         var superLikeFrame = view.FindByName<Frame>("SuperLikeFrame");
-        var threshold = (BindingContext as TinderPageViewModel).Threshold;
+        var threshold = (BindingContext as TinderPageViewModel)?.Threshold ?? 100;
 
         var draggedXPercent = e.DistanceDraggedX / threshold;
 

--- a/src/Plugin.Maui.SwipeCardView/Core/DraggingCardEventArgs.cs
+++ b/src/Plugin.Maui.SwipeCardView/Core/DraggingCardEventArgs.cs
@@ -1,9 +1,11 @@
-﻿namespace Plugin.Maui.SwipeCardView.Core;
+﻿using Microsoft.Maui.Controls;
 
-/// <summary>Arguments for swipe events.</summary>
+namespace Plugin.Maui.SwipeCardView.Core;
+
+/// <summary>Arguments for drag events raised while a card is being dragged.</summary>
 public class DraggingCardEventArgs : System.EventArgs
 {
-    public DraggingCardEventArgs(object item, object parameter, SwipeCardDirection direction, DraggingCardPosition position, double distanceDraggedX, double distanceDraggedY)
+    public DraggingCardEventArgs(object item, object parameter, SwipeCardDirection direction, DraggingCardPosition position, double distanceDraggedX, double distanceDraggedY, View? cardView = null)
     {
         Item = item;
         Parameter = parameter;
@@ -11,23 +13,27 @@ public class DraggingCardEventArgs : System.EventArgs
         Position = position;
         DistanceDraggedX = distanceDraggedX;
         DistanceDraggedY = distanceDraggedY;
+        CardView = cardView;
     }
 
-    /// <summary>Gets the item parameter.</summary>
-    public object Item { get; private set; }
+    /// <summary>Gets the data item bound to the card being dragged.</summary>
+    public object Item { get; }
 
     /// <summary>Gets the command parameter.</summary>
-    public object Parameter { get; private set; }
+    public object Parameter { get; }
 
-    /// <summary>Gets the direction of the swipe.</summary>
-    public SwipeCardDirection Direction { get; private set; }
+    /// <summary>Gets the direction of the drag.</summary>
+    public SwipeCardDirection Direction { get; }
 
-    /// <summary>Gets the dragging position.</summary>
-    public DraggingCardPosition Position { get; private set; }
+    /// <summary>Gets the current dragging position relative to the threshold.</summary>
+    public DraggingCardPosition Position { get; }
 
-    /// <summary>Gets the distance dragged on X axis.</summary>
-    public double DistanceDraggedX { get; private set; }
+    /// <summary>Gets the distance dragged on the X axis (in device-independent units).</summary>
+    public double DistanceDraggedX { get; }
 
-    /// <summary>Gets the distance dragged on Y axis.</summary>
-    public double DistanceDraggedY { get; private set; }
+    /// <summary>Gets the distance dragged on the Y axis (in device-independent units).</summary>
+    public double DistanceDraggedY { get; }
+
+    /// <summary>Gets the card view being dragged. Use this to find named elements within the card's DataTemplate (e.g. <c>CardView.FindByName&lt;Label&gt;("MyLabel")</c>).</summary>
+    public View? CardView { get; }
 }

--- a/src/Plugin.Maui.SwipeCardView/Core/SwipedCardEventArgs.cs
+++ b/src/Plugin.Maui.SwipeCardView/Core/SwipedCardEventArgs.cs
@@ -1,6 +1,6 @@
 ﻿namespace Plugin.Maui.SwipeCardView.Core;
 
-/// <summary>Arguments for swipe events.</summary>
+/// <summary>Arguments for swipe events raised when a card is swiped past the threshold.</summary>
 public class SwipedCardEventArgs : System.EventArgs
 {
     public SwipedCardEventArgs(object item, object parameter,
@@ -11,12 +11,12 @@ public class SwipedCardEventArgs : System.EventArgs
         Direction = direction;
     }
 
-    /// <summary>Gets the item parameter.</summary>
-    public object Item { get; private set; }
+    /// <summary>Gets the data item bound to the swiped card.</summary>
+    public object Item { get; }
 
     /// <summary>Gets the command parameter.</summary>
-    public object Parameter { get; private set; }
+    public object Parameter { get; }
 
-    /// <summary>Gets the direction of the swipe.</summary>
-    public SwipeCardDirection Direction { get; private set; }
+    /// <summary>Gets the direction the card was swiped.</summary>
+    public SwipeCardDirection Direction { get; }
 }

--- a/src/Plugin.Maui.SwipeCardView/Plugin.Maui.SwipeCardView.csproj
+++ b/src/Plugin.Maui.SwipeCardView/Plugin.Maui.SwipeCardView.csproj
@@ -8,6 +8,9 @@
 		<Nullable>enable</Nullable>
 		<UseMaui>true</UseMaui>
 
+		<!-- Version: overridden by CI via -p:PackageVersion=X.Y.Z -->
+		<Version>0.0.0-local</Version>
+
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -91,7 +91,8 @@ public class SwipeCardView : ContentView, IDisposable
             nameof(BackCardScale),
             typeof(float),
             typeof(SwipeCardView),
-            DefaultBackCardScale);
+            DefaultBackCardScale,
+            validateValue: (_, value) => value is float f && f > 0f && f <= 1f);
 
     public static readonly BindableProperty CardRotationProperty =
         BindableProperty.Create(
@@ -158,6 +159,7 @@ public class SwipeCardView : ContentView, IDisposable
 
     private bool _disposed = false;
     private bool _programmaticSwipe = false;
+    private int _collectionVersion = 0;
     private INotifyCollectionChanged? _subscribedCollection;
 
     #endregion Private fields
@@ -175,94 +177,111 @@ public class SwipeCardView : ContentView, IDisposable
 
     #region Public Properties
 
+    /// <summary>Occurs when a card is swiped past the threshold distance.</summary>
     public event EventHandler<SwipedCardEventArgs>? Swiped;
 
+    /// <summary>Occurs continuously while a card is being dragged, reporting direction, position, and distance.</summary>
     public event EventHandler<DraggingCardEventArgs>? Dragging;
 
+    /// <summary>Gets or sets the data source for the card stack. Must implement <see cref="IList"/> (e.g. <see cref="System.Collections.ObjectModel.ObservableCollection{T}"/>).</summary>
     public IList ItemsSource
     {
         get => (IList)GetValue(ItemsSourceProperty);
         set => SetValue(ItemsSourceProperty, value);
     }
 
+    /// <summary>Gets or sets the <see cref="DataTemplate"/> used to render each card.</summary>
     public DataTemplate ItemTemplate
     {
         get => (DataTemplate)GetValue(ItemTemplateProperty);
         set => SetValue(ItemTemplateProperty, value);
     }
 
+    /// <summary>Gets the data item of the currently displayed top card (one-way-to-source).</summary>
     public object? TopItem
     {
         get => GetValue(TopItemProperty);
         set => SetValue(TopItemProperty, value);
     }
 
+    /// <summary>Gets the data item of the previously swiped card, or null if at the first item (one-way-to-source).</summary>
     public object? PreviousItem
     {
         get => GetValue(PreviousItemProperty);
         set => SetValue(PreviousItemProperty, value);
     }
 
+    /// <summary>Gets or sets the command executed when a card is swiped. Receives <see cref="SwipedCardEventArgs"/>.</summary>
     public ICommand SwipedCommand
     {
         get => (ICommand)GetValue(SwipedCommandProperty);
         set => SetValue(SwipedCommandProperty, value);
     }
 
+    /// <summary>Gets or sets an optional parameter included in <see cref="SwipedCardEventArgs.Parameter"/>.</summary>
     public object SwipedCommandParameter
     {
         get => GetValue(SwipedCommandParameterProperty);
         set => SetValue(SwipedCommandParameterProperty, value);
     }
 
+    /// <summary>Gets or sets the command executed continuously while dragging. Receives <see cref="DraggingCardEventArgs"/>.</summary>
     public ICommand DraggingCommand
     {
         get => (ICommand)GetValue(DraggingCommandProperty);
         set => SetValue(DraggingCommandProperty, value);
     }
 
+    /// <summary>Gets or sets an optional parameter included in <see cref="DraggingCardEventArgs.Parameter"/>.</summary>
     public object DraggingCommandParameter
     {
         get => GetValue(DraggingCommandParameterProperty);
         set => SetValue(DraggingCommandParameterProperty, value);
     }
 
+    /// <summary>Gets or sets the minimum drag distance (in device-independent units) to trigger a swipe. Default is 100.</summary>
     public uint Threshold
     {
         get => (uint)GetValue(ThresholdProperty);
         set => SetValue(ThresholdProperty, value);
     }
 
+    /// <summary>Gets or sets which directions are allowed to complete a swipe. Default is all four.</summary>
     public SwipeCardDirection SupportedSwipeDirections
     {
         get => (SwipeCardDirection)GetValue(SupportedSwipeDirectionsProperty);
         set => SetValue(SupportedSwipeDirectionsProperty, value);
     }
 
+    /// <summary>Gets or sets which drag directions generate drag events. Default is all four.</summary>
     public SwipeCardDirection SupportedDraggingDirections
     {
         get => (SwipeCardDirection)GetValue(SupportedDraggingDirectionsProperty);
         set => SetValue(SupportedDraggingDirectionsProperty, value);
     }
 
+    /// <summary>Gets or sets the initial scale of the back card (0.0–1.0). Scales up to 1.0 as the top card is dragged. Default is 0.8.</summary>
     public float BackCardScale
     {
         get => (float)GetValue(BackCardScaleProperty);
         set => SetValue(BackCardScaleProperty, value);
     }
 
+    /// <summary>Gets or sets the maximum rotation angle (degrees) applied during horizontal drag. Default is 20.</summary>
     public float CardRotation
     {
         get => (float)GetValue(CardRotationProperty);
         set => SetValue(CardRotationProperty, value);
     }
 
+    /// <summary>Gets or sets the duration (milliseconds) of swipe and snap-back animations. Default is 250.</summary>
     public uint AnimationLength
     {
         get => (uint)GetValue(AnimationLengthProperty);
         set => SetValue(AnimationLengthProperty, value);
     }
 
+    /// <summary>Gets or sets whether the card stack loops back to the first item after the last card is swiped. Default is false.</summary>
     public bool LoopCards
     {
         get => (bool)GetValue(LoopCardsProperty);
@@ -273,6 +292,7 @@ public class SwipeCardView : ContentView, IDisposable
 
     #region Public Methods
 
+    /// <summary>Releases all resources used by the <see cref="SwipeCardView"/>.</summary>
     public void Dispose()
     {
         Dispose(true);
@@ -390,8 +410,6 @@ public class SwipeCardView : ContentView, IDisposable
         }
     }
 
-    #endregion Public Methods
-
     /// <summary>
     /// Goes back to the previously swiped card without animation. Returns true if successful,
     /// false if already at the first item or no items are available.
@@ -441,6 +459,8 @@ public class SwipeCardView : ContentView, IDisposable
         ShowPreviousCard(animated);
         return true;
     }
+
+    #endregion Public Methods
 
     #region Event Handlers
 
@@ -493,10 +513,27 @@ public class SwipeCardView : ContentView, IDisposable
         var swipeCardView = (SwipeCardView)bindable;
         swipeCardView.UnsubscribeCollectionChanged();
 
+        swipeCardView._collectionVersion++;
         swipeCardView._itemIndex = 0;
         swipeCardView._currentDisplayIndex = 0;
-        swipeCardView.Setup();
 
+        if (newValue == null)
+        {
+            // Clear all cards when ItemsSource is set to null
+            foreach (var card in swipeCardView._cards)
+            {
+                if (card != null)
+                {
+                    Microsoft.Maui.Controls.ViewExtensions.CancelAnimations(card);
+                    card.IsVisible = false;
+                }
+            }
+            swipeCardView.TopItem = null;
+            swipeCardView.PreviousItem = null;
+            return;
+        }
+
+        swipeCardView.Setup();
         swipeCardView.SubscribeCollectionChanged();
     }
 
@@ -525,6 +562,8 @@ public class SwipeCardView : ContentView, IDisposable
         {
             return;
         }
+
+        _collectionVersion++;
 
         switch (e.Action)
         {
@@ -613,6 +652,22 @@ public class SwipeCardView : ContentView, IDisposable
                     _currentDisplayIndex = Math.Max(0, _currentDisplayIndex - removeCount);
                     _itemIndex = Math.Max(0, _itemIndex - removeCount);
                 }
+                else if (e.OldStartingIndex > _currentDisplayIndex)
+                {
+                    // An item after current was removed — update _itemIndex and rebind back card if needed
+                    _itemIndex = Math.Min(_itemIndex, ItemsSource.Count);
+                    var backIdx = NextCardIndex(_topCardIndex);
+                    var backCard = _cards[backIdx];
+                    if (backCard.IsVisible && _currentDisplayIndex + 1 < ItemsSource.Count)
+                    {
+                        backCard.BindingContext = ItemsSource[_currentDisplayIndex + 1];
+                    }
+                    else if (backCard.IsVisible)
+                    {
+                        backCard.IsVisible = false;
+                        backCard.Opacity = 0;
+                    }
+                }
                 break;
 
             case NotifyCollectionChangedAction.Replace:
@@ -644,7 +699,7 @@ public class SwipeCardView : ContentView, IDisposable
         }
     }
 
-    private void OnPanUpdated(object? sender, PanUpdatedEventArgs e)
+    private async void OnPanUpdated(object? sender, PanUpdatedEventArgs e)
     {
         if (_disposed || _programmaticSwipe || ItemsSource == null || ItemsSource.Count == 0)
         {
@@ -662,11 +717,11 @@ public class SwipeCardView : ContentView, IDisposable
                 break;
 
             case GestureStatus.Completed:
-                _ = HandleTouchEnd();
+                await HandleTouchEnd();
                 break;
 
             case GestureStatus.Canceled:
-                _ = HandleTouchEnd();
+                await HandleTouchEnd();
                 break;
         }
     }
@@ -898,8 +953,16 @@ public class SwipeCardView : ContentView, IDisposable
                 topCard.TranslationX = 0;
                 topCard.TranslationY = -topCard.Y;
 
+                var collectionVersionBeforeSwipe = _collectionVersion;
                 SendSwiped(topCard, direction);
-                ShowNextCard();
+
+                // Only advance to next card if the collection wasn't modified by the Swiped handler.
+                // If a handler removed the swiped item (common pattern), OnItemSourceCollectionChanged
+                // already updated internal state — calling ShowNextCard would double-advance.
+                if (_collectionVersion == collectionVersionBeforeSwipe)
+                {
+                    ShowNextCard();
+                }
             }
             else
             {
@@ -984,9 +1047,15 @@ public class SwipeCardView : ContentView, IDisposable
 
         // If there are more cards to show, recycle the old top card
         // for the next item in the source
+        if (_itemIndex >= ItemsSource.Count && LoopCards)
+        {
+            _itemIndex = 0;
+        }
+
         if (_itemIndex < ItemsSource.Count)
         {
             // Cancel any lingering animations before recycling
+            if (oldTopCard == null) return;
             oldTopCard.CancelAnimations();
 
             // Push it behind the top card
@@ -1009,10 +1078,12 @@ public class SwipeCardView : ContentView, IDisposable
 
     private async void ShowPreviousCard(bool animated = false)
     {
-        if (ItemsSource == null || ItemsSource.Count == 0)
+        try
         {
-            return;
-        }
+            if (ItemsSource == null || ItemsSource.Count == 0)
+            {
+                return;
+            }
 
         // Use _currentDisplayIndex for O(1) index resolution (handles duplicates correctly)
         var previousItem = ItemsSource[_currentDisplayIndex - 1];
@@ -1112,6 +1183,11 @@ public class SwipeCardView : ContentView, IDisposable
         {
             // No dispatcher available (e.g. unit test context) — skip layout invalidation
         }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"ShowPreviousCard error: {ex}");
+        }
     }
 
     // Return the next card index from the top
@@ -1161,12 +1237,12 @@ public class SwipeCardView : ContentView, IDisposable
             cmd.Execute(args);
         }
 
-        Swiped?.Invoke(sender, args);
+        Swiped?.Invoke(this, args);
     }
 
     private void SendDragging(View sender, SwipeCardDirection direction, DraggingCardPosition position, double distanceDraggedX, double distanceDraggedY)
     {
-        var args = new DraggingCardEventArgs(sender.BindingContext, DraggingCommandParameter, direction, position, distanceDraggedX, distanceDraggedY);
+        var args = new DraggingCardEventArgs(sender.BindingContext, DraggingCommandParameter, direction, position, distanceDraggedX, distanceDraggedY, sender);
 
         var cmd = DraggingCommand;
         if (cmd != null && cmd.CanExecute(args))
@@ -1174,7 +1250,7 @@ public class SwipeCardView : ContentView, IDisposable
             cmd.Execute(args);
         }
 
-        Dragging?.Invoke(sender, args);
+        Dragging?.Invoke(this, args);
     }
 
     #endregion Private Methods


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Overview

Multi-model code review (Claude Opus 4.6, GPT-5.2-Codex, Claude Sonnet 4.5) identified 12 actionable issues. This PR fixes all of them.

## Critical Fixes

### 1. Event \\sender\\ is now \\	his\\ (SwipeCardView)
Previously, \\Swiped\\ and \\Dragging\\ events passed the internal card \\View\\ as sender. Consumers casting \\(SwipeCardView)sender\\ would get an \\InvalidCastException\\. Now follows .NET convention with sender = \\	his\\.

Added \\CardView\\ property to \\DraggingCardEventArgs\\ so consumers can still access the card's DataTemplate elements (e.g. \\.CardView.FindByName<Label>("MyLabel")\\).

### 2. \\ShowPreviousCard\\ crash prevention
\\sync void\\ method now wrapped in try/catch to prevent unhandled exceptions from crashing the app.

### 3. \\OnPanUpdated\\ properly awaits \\HandleTouchEnd\\
Changed from \\_ = HandleTouchEnd()\\ (fire-and-forget) to \\wait HandleTouchEnd()\\ with \\sync void\\ event handler.

## Important Fixes

| Fix | Description |
|-----|-------------|
| **Swiped handler mutation guard** | If a Swiped handler modifies ItemsSource, the control no longer double-advances (version counter guards ShowNextCard) |
| **Remove after current** | Removing the back card's item now rebinds or hides it instead of leaving stale content |
| **ItemsSource = null** | Properly clears cards and resets TopItem/PreviousItem |
| **LoopCards in ShowNextCard** | Seamless wrapping when \\_itemIndex\\ reaches end (no visual flash on reinit) |
| **BackCardScale validation** | Rejects values outside (0.0, 1.0] to prevent broken scaling math |
| **Version in csproj** | Added \\