### PR TITLE
Fix review pass 2: LoopCards GoBack, binary compat, PreviousItem cleanup

### DIFF
--- a/src/Plugin.Maui.SwipeCardView.Tests/UnitTests.cs
+++ b/src/Plugin.Maui.SwipeCardView.Tests/UnitTests.cs
@@ -621,4 +621,43 @@ public class UnitTests : TestBase
         Assert.AreEqual("MyParam", args.Parameter);
         Assert.AreEqual(SwipeCardDirection.Right, args.Direction);
     }
+
+    [TestMethod]
+    public async Task GoBack_AfterLoopCycle_ShouldNotThrow()
+    {
+        var items = new ObservableCollection<string> { "A", "B", "C" };
+        var swipeCardView = new SwipeCardView
+        {
+            ItemsSource = items,
+            ItemTemplate = CreateSimpleTemplate(),
+            LoopCards = true
+        };
+
+        // Swipe through full cycle + 1 extra
+        for (int i = 0; i < 4; i++)
+        {
+            await swipeCardView.InvokeSwipe(SwipeCardDirection.Right);
+        }
+
+        // GoBack should work without throwing
+        var result = swipeCardView.GoBack();
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public async Task PreviousItem_ClearedOnCollectionReset()
+    {
+        var items = new ObservableCollection<string> { "A", "B", "C" };
+        var swipeCardView = new SwipeCardView
+        {
+            ItemsSource = items,
+            ItemTemplate = CreateSimpleTemplate()
+        };
+
+        await swipeCardView.InvokeSwipe(SwipeCardDirection.Right);
+        Assert.IsNotNull(swipeCardView.PreviousItem);
+
+        items.Clear();
+        Assert.IsNull(swipeCardView.PreviousItem);
+    }
 }

--- a/src/Plugin.Maui.SwipeCardView/Core/DraggingCardEventArgs.cs
+++ b/src/Plugin.Maui.SwipeCardView/Core/DraggingCardEventArgs.cs
@@ -5,7 +5,14 @@ namespace Plugin.Maui.SwipeCardView.Core;
 /// <summary>Arguments for drag events raised while a card is being dragged.</summary>
 public class DraggingCardEventArgs : System.EventArgs
 {
-    public DraggingCardEventArgs(object item, object parameter, SwipeCardDirection direction, DraggingCardPosition position, double distanceDraggedX, double distanceDraggedY, View? cardView = null)
+    /// <summary>Creates a new instance without a card view reference.</summary>
+    public DraggingCardEventArgs(object item, object parameter, SwipeCardDirection direction, DraggingCardPosition position, double distanceDraggedX, double distanceDraggedY)
+        : this(item, parameter, direction, position, distanceDraggedX, distanceDraggedY, null)
+    {
+    }
+
+    /// <summary>Creates a new instance with a card view reference.</summary>
+    public DraggingCardEventArgs(object item, object parameter, SwipeCardDirection direction, DraggingCardPosition position, double distanceDraggedX, double distanceDraggedY, View? cardView)
     {
         Item = item;
         Parameter = parameter;

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -583,6 +583,7 @@ public class SwipeCardView : ContentView, IDisposable
 
                 _ignoreTouch = false;
                 TopItem = null;
+                PreviousItem = null;
                 if (ItemsSource != null && ItemsSource.Count > 0)
                     Setup();
                 break;
@@ -637,6 +638,7 @@ public class SwipeCardView : ContentView, IDisposable
                     _itemIndex = 0;
                     _currentDisplayIndex = 0;
                     TopItem = null;
+                    PreviousItem = null;
                 }
                 else if (e.OldStartingIndex == _currentDisplayIndex)
                 {
@@ -1027,6 +1029,12 @@ public class SwipeCardView : ContentView, IDisposable
         // Set TopItem to the binding context of the new top card
         TopItem = _cards[_topCardIndex]?.BindingContext;
         _currentDisplayIndex++;
+
+        // Keep _currentDisplayIndex in range when looping
+        if (LoopCards && ItemsSource != null && ItemsSource.Count > 0)
+        {
+            _currentDisplayIndex = _currentDisplayIndex % ItemsSource.Count;
+        }
 
         // Track the previous item for GoBack support
         PreviousItem = oldTopCard?.BindingContext;


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could <a href="https://github.com/dotnet/maui/wiki/Testing-PR-Builds">test the resulting artifacts</a> from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Fixes 3 findings from the second multi-model review pass (Opus 4.6 + GPT-5.2-Codex) after merging PR #15.

### Fixes

1. **GoBack() after LoopCards full cycle** (Opus 4.6 — Medium)
   - `_currentDisplayIndex` was never wrapped for `LoopCards=true`, causing `ArgumentOutOfRangeException` when GoBack() was called after swiping through a full cycle + 1
   - Fix: wrap `_currentDisplayIndex` modulo `ItemsSource.Count` in ShowNextCard when LoopCards is true

2. **DraggingCardEventArgs binary compatibility** (GPT-5.2-Codex — High)
   - PR #15 changed the constructor from 6 params to 7 (with optional `cardView`), breaking binary compatibility for compiled consumers
   - Fix: restored original 6-parameter constructor as an overload that delegates to the 7-param version

3. **PreviousItem stale on collection reset/clear** (GPT-5.2-Codex — Medium)
   - `PreviousItem` was not cleared when the collection was reset or all items were removed, leaving bindings pointing at non-existent items
   - Fix: explicitly set `PreviousItem = null` in both Reset and Remove-all-items branches

### Tests

- 2 new tests added (35 total, all passing):
  - `GoBack_AfterLoopCycle_ShouldNotThrow` — swipes 4 times through a 3-item looping collection, then GoBack succeeds
  - `PreviousItem_ClearedOnCollectionReset` — verifies PreviousItem is null after `items.Clear()`