### PR TITLE
feat: Add StackDepth property for card stack visual effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,11 @@ Show stacked cards behind the top card to create the visual illusion of a deck. 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `StackDepth` | `int` | `0` | Number of cards visible behind the top card. `0` = off (backward compatible), `1` = back card visible, `2` = back card + 1 shadow, etc. |
-| `StackOffset` | `double` | `8` | Vertical offset (in dp) between each stacked card |
-| `StackScaleStep` | `double` | `0.02` | Scale reduction per successive card (e.g., 0.02 = each card 2% smaller). Set to `0` for uniform-width strips. |
+| `StackOffset` | `double` | `10` | Vertical offset (in dp) between each stacked card |
+| `StackScaleStep` | `double` | `0.03` | Scale reduction per successive card (e.g., 0.02 = each card 2% smaller). Set to `0` for uniform-width strips. |
 | `StackDirection` | `StackDirection` | `Bottom` | Direction stacked cards peek: `Bottom` (below top card) or `Top` (above top card) |
 
-The `BackCardScale` property controls the scale of the first back card. When `StackDepth` > 1, successive shadow cards scale down further by `StackScaleStep` each.
+In non-stack mode (`StackDepth` = 0), the `BackCardScale` property controls the initial scale of the back card during drag. In stack mode (`StackDepth` > 0), card scaling is driven by `StackScaleStep` for visual consistency across all strips.
 
 All stack properties can be changed at runtime and take effect immediately — no swipe action needed.
 

--- a/README.md
+++ b/README.md
@@ -182,18 +182,21 @@ Show stacked cards behind the top card to create the visual illusion of a deck. 
 ```xml
 <swipeCardView:SwipeCardView
     ItemsSource="{Binding Profiles}"
-    StackDepth="2"
-    StackOffset="15"
-    StackDirection="Bottom"
-    BackCardScale="0.95" />
+    StackDepth="3"
+    StackOffset="5"
+    StackDirection="Top"
+    StackScaleStep="0"
+    StackCardColor="#5A7050"
+    BackCardScale="0.98" />
 ```
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `StackDepth` | `int` | `0` | Number of cards visible behind the top card. `0` = off (backward compatible), `1` = back card visible, `2` = back card + 1 shadow, etc. |
-| `StackOffset` | `double` | `10` | Vertical offset (in dp) between each stacked card |
-| `StackScaleStep` | `double` | `0.03` | Scale reduction per successive card (e.g., 0.03 = each card 3% smaller) |
+| `StackOffset` | `double` | `8` | Vertical offset (in dp) between each stacked card |
+| `StackScaleStep` | `double` | `0.02` | Scale reduction per successive card (e.g., 0.02 = each card 2% smaller). Set to `0` for uniform-width strips. |
 | `StackDirection` | `StackDirection` | `Bottom` | Direction stacked cards peek: `Bottom` (below top card) or `Top` (above top card) |
+| `StackCardColor` | `Color?` | `null` | Color for stack strips and back card overlay. When set, shows graduated colors (lighter at deeper levels) and covers the back card with an overlay that fades during swipe. |
 
 The `BackCardScale` property controls the scale of the first back card. When `StackDepth` > 1, successive shadow cards scale down further by `StackScaleStep` each.
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ Show stacked cards behind the top card to create the visual illusion of a deck. 
     StackOffset="5"
     StackDirection="Top"
     StackScaleStep="0"
-    StackCardColor="#5A7050"
     BackCardScale="0.98" />
 ```
 
@@ -196,7 +195,6 @@ Show stacked cards behind the top card to create the visual illusion of a deck. 
 | `StackOffset` | `double` | `8` | Vertical offset (in dp) between each stacked card |
 | `StackScaleStep` | `double` | `0.02` | Scale reduction per successive card (e.g., 0.02 = each card 2% smaller). Set to `0` for uniform-width strips. |
 | `StackDirection` | `StackDirection` | `Bottom` | Direction stacked cards peek: `Bottom` (below top card) or `Top` (above top card) |
-| `StackCardColor` | `Color?` | `null` | Color for stack strips and back card overlay. When set, shows graduated colors (lighter at deeper levels) and covers the back card with an overlay that fades during swipe. |
 
 The `BackCardScale` property controls the scale of the first back card. When `StackDepth` > 1, successive shadow cards scale down further by `StackScaleStep` each.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Install with the dotnet CLI: `dotnet add package Plugin.Maui.SwipeCardView`, or 
 - **Navigation** – Go back to previously swiped cards with `GoBack()`, optionally with animation
 - **Programmatic Swiping** – Trigger swipes from code with `InvokeSwipe()`
 - **Looping** – Enable infinite card looping with the `LoopCards` property
+- **Card Stack** – Show stacked cards behind the top card with `StackDepth`, giving the visual illusion of a deck
 - **Disposable** – Proper resource cleanup with `IDisposable` implementation
 
 For more info about the features check out [the full documentation](docs/index.md).
@@ -173,6 +174,28 @@ Enable infinite card looping so the stack cycles back to the first card after re
     ItemsSource="{Binding CardItems}"
     LoopCards="True" />
 ```
+
+## Card Stack Visual Effect
+
+Show stacked cards behind the top card to create the visual illusion of a deck. Set `StackDepth` to control how many cards are visible:
+
+```xml
+<swipeCardView:SwipeCardView
+    ItemsSource="{Binding Profiles}"
+    StackDepth="2"
+    StackOffset="15"
+    BackCardScale="0.95" />
+```
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `StackDepth` | `int` | `0` | Number of cards visible behind the top card. `0` = off (backward compatible), `1` = back card visible, `2` = back card + 1 shadow, etc. |
+| `StackOffset` | `double` | `10` | Vertical offset (in dp) between each stacked card |
+| `StackScaleStep` | `double` | `0.03` | Scale reduction per successive card (e.g., 0.03 = each card 3% smaller) |
+
+The `BackCardScale` property controls the scale of the first back card. When `StackDepth` > 1, successive shadow cards scale down further by `StackScaleStep` each.
+
+> **Note:** `StackDepth="0"` is fully backward compatible — the control behaves exactly as before.
 
 ## Migration From SwipeCardView for Xamarin.Forms
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ In non-stack mode (`StackDepth` = 0), the `BackCardScale` property controls the 
 
 All stack properties can be changed at runtime and take effect immediately — no swipe action needed.
 
+**Dynamic depth:** When `LoopCards` is disabled, the visible strip count automatically decreases as the user approaches the end of the collection. For example, with `StackDepth="3"` and 2 cards remaining, only 1 strip is shown; on the very last card, no strips are shown. When `LoopCards` is enabled, all strips remain visible since there are always more cards in the loop.
+
 > **Note:** `StackDepth="0"` is fully backward compatible — the control behaves exactly as before.
 
 ## Migration From SwipeCardView for Xamarin.Forms

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Show stacked cards behind the top card to create the visual illusion of a deck. 
     ItemsSource="{Binding Profiles}"
     StackDepth="2"
     StackOffset="15"
+    StackDirection="Bottom"
     BackCardScale="0.95" />
 ```
 
@@ -192,8 +193,11 @@ Show stacked cards behind the top card to create the visual illusion of a deck. 
 | `StackDepth` | `int` | `0` | Number of cards visible behind the top card. `0` = off (backward compatible), `1` = back card visible, `2` = back card + 1 shadow, etc. |
 | `StackOffset` | `double` | `10` | Vertical offset (in dp) between each stacked card |
 | `StackScaleStep` | `double` | `0.03` | Scale reduction per successive card (e.g., 0.03 = each card 3% smaller) |
+| `StackDirection` | `StackDirection` | `Bottom` | Direction stacked cards peek: `Bottom` (below top card) or `Top` (above top card) |
 
 The `BackCardScale` property controls the scale of the first back card. When `StackDepth` > 1, successive shadow cards scale down further by `StackScaleStep` each.
+
+All stack properties can be changed at runtime and take effect immediately — no swipe action needed.
 
 > **Note:** `StackDepth="0"` is fully backward compatible — the control behaves exactly as before.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,6 +17,9 @@ ItemsSource | `System.Collections.IList` | null | Gets or sets the source of ite
 ItemTemplate | `Microsoft.Maui.Controls.DataTemplate` | null | Gets or sets the DataTemplate to apply to the ItemsSource. Supports any View as root, including `Border`
 LoopCards | `bool` | false | Gets or sets whether the card stack loops back to the first card after reaching the end
 PreviousItem | `System.Object` | null | Gets the previously swiped item (read-only, OneWayToSource). Cleared on collection Reset or when all items are removed
+StackDepth | `int` | 0 | Number of cards visible behind the top card. 0 = off (backward compatible), 1 = back card visible, 2+ = back card plus shadow cards
+StackOffset | `double` | 10 | Vertical offset in device-independent units between each stacked card
+StackScaleStep | `double` | 0.03 | Scale reduction applied to each successive card in the stack (e.g., 0.03 = each card 3% smaller)
 SupportedDraggingDirections | `SwipeCardDirection` | Left, Right, Up, Down | Gets or sets supported dragging direction of the top card
 SupportedSwipeDirections | `SwipeCardDirection` | Left, Right, Up, Down | Gets or sets direction in which top card could be swiped
 SwipedCommand | `System.Windows.Input.ICommand`  | null | Gets or sets the command to run when a swipe gesture is recognized. Receives `SwipedCardEventArgs` as parameter (or `SwipedCommandParameter` if set)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - **Card Stack Visual Effect** — New `StackDepth` property to show stacked cards behind the top card, creating a visual deck effect. When enabled, the back card is visible at rest and decorative shadow cards peek below for depth
 - **StackOffset property** — Controls the vertical offset (in dp) between each stacked card (default: 10)
 - **StackScaleStep property** — Controls the scale reduction per successive shadow card (default: 0.03)
+- **Dynamic stack depth** — When `LoopCards` is disabled, visible strip count automatically decreases as remaining cards drop below `StackDepth`, providing a realistic deck-depletion effect
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.0
+
+### Added
+
+- **Card Stack Visual Effect** — New `StackDepth` property to show stacked cards behind the top card, creating a visual deck effect. When enabled, the back card is visible at rest and decorative shadow cards peek below for depth
+- **StackOffset property** — Controls the vertical offset (in dp) between each stacked card (default: 10)
+- **StackScaleStep property** — Controls the scale reduction per successive shadow card (default: 0.03)
+
+### Fixed
+
+- **Memory leak in Dispose** — Shadow card `Border` elements are now properly disposed when the control is disposed
+- **SizeChanged handler leak** — `OnSizeChangedForStack` event handler is now unsubscribed in `Dispose()` to prevent leaks when the control is disposed before layout completes
+- **CS8602 null warning** — Added null check for `ItemsSource` before accessing `.Count`
+- **StackScaleStep documentation** — Fixed XML doc that incorrectly stated default was 0.04 (actual: 0.03)
+
+## 1.0.1
+
+### Fixed
+
+- **GoBack card ordering** — Fixed ZIndex race condition where the restored card could appear behind the current top card
+- **GoBack item tracking** — Fixed off-by-one error in `_itemIndex` after GoBack, which caused the wrong next card to load
+
 ## 1.0.0
 
 ### Added

--- a/samples/SwipeCardView.Sample/ViewModels/CustomizablePageViewModel.cs
+++ b/samples/SwipeCardView.Sample/ViewModels/CustomizablePageViewModel.cs
@@ -34,7 +34,6 @@ public class CustomizablePageViewModel : BasePageViewModel
     private double _stackOffset;
     private double _stackScaleStep;
     private StackDirection _stackDirection;
-    private Color? _stackCardColor;
 
     public CustomizablePageViewModel()
     {
@@ -65,7 +64,6 @@ public class CustomizablePageViewModel : BasePageViewModel
         _stackOffset = 8;
         _stackScaleStep = 0.02;
         _stackDirection = StackDirection.Bottom;
-        _stackCardColor = null;
 
         SwipedCommand = new Command<SwipedCardEventArgs>(OnSwipedCommand);
         DraggingCommand = new Command<DraggingCardEventArgs>(OnDraggingCommand);
@@ -289,35 +287,6 @@ public class CustomizablePageViewModel : BasePageViewModel
         set
         {
             StackDirection = value ? StackDirection.Top : StackDirection.Bottom;
-        }
-    }
-
-    public Color? StackCardColor
-    {
-        get => _stackCardColor;
-        set
-        {
-            _stackCardColor = value;
-            RaisePropertyChanged();
-        }
-    }
-
-    public string StackCardColorText
-    {
-        get => _stackCardColor != null ? _stackCardColor.ToArgbHex() : "";
-        set
-        {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                StackCardColor = null;
-            }
-            else
-            {
-                var hex = value.StartsWith("#") ? value : "#" + value;
-                try { StackCardColor = Color.FromArgb(hex); }
-                catch { /* ignore invalid color strings */ }
-            }
-            RaisePropertyChanged();
         }
     }
 

--- a/samples/SwipeCardView.Sample/ViewModels/CustomizablePageViewModel.cs
+++ b/samples/SwipeCardView.Sample/ViewModels/CustomizablePageViewModel.cs
@@ -33,6 +33,7 @@ public class CustomizablePageViewModel : BasePageViewModel
     private int _stackDepth;
     private double _stackOffset;
     private double _stackScaleStep;
+    private StackDirection _stackDirection;
 
     public CustomizablePageViewModel()
     {
@@ -62,6 +63,7 @@ public class CustomizablePageViewModel : BasePageViewModel
         _stackDepth = 0;
         _stackOffset = 10;
         _stackScaleStep = 0.03;
+        _stackDirection = StackDirection.Bottom;
 
         SwipedCommand = new Command<SwipedCardEventArgs>(OnSwipedCommand);
         DraggingCommand = new Command<DraggingCardEventArgs>(OnDraggingCommand);
@@ -265,6 +267,26 @@ public class CustomizablePageViewModel : BasePageViewModel
         {
             _stackScaleStep = value;
             RaisePropertyChanged();
+        }
+    }
+
+    public StackDirection StackDirection
+    {
+        get => _stackDirection;
+        set
+        {
+            _stackDirection = value;
+            RaisePropertyChanged();
+            RaisePropertyChanged(nameof(IsStackDirectionTop));
+        }
+    }
+
+    public bool IsStackDirectionTop
+    {
+        get => _stackDirection == StackDirection.Top;
+        set
+        {
+            StackDirection = value ? StackDirection.Top : StackDirection.Bottom;
         }
     }
 

--- a/samples/SwipeCardView.Sample/ViewModels/CustomizablePageViewModel.cs
+++ b/samples/SwipeCardView.Sample/ViewModels/CustomizablePageViewModel.cs
@@ -34,6 +34,7 @@ public class CustomizablePageViewModel : BasePageViewModel
     private double _stackOffset;
     private double _stackScaleStep;
     private StackDirection _stackDirection;
+    private Color? _stackCardColor;
 
     public CustomizablePageViewModel()
     {
@@ -61,9 +62,10 @@ public class CustomizablePageViewModel : BasePageViewModel
         _cardRotation = 20;
 
         _stackDepth = 0;
-        _stackOffset = 10;
-        _stackScaleStep = 0.03;
+        _stackOffset = 8;
+        _stackScaleStep = 0.02;
         _stackDirection = StackDirection.Bottom;
+        _stackCardColor = null;
 
         SwipedCommand = new Command<SwipedCardEventArgs>(OnSwipedCommand);
         DraggingCommand = new Command<DraggingCardEventArgs>(OnDraggingCommand);
@@ -287,6 +289,35 @@ public class CustomizablePageViewModel : BasePageViewModel
         set
         {
             StackDirection = value ? StackDirection.Top : StackDirection.Bottom;
+        }
+    }
+
+    public Color? StackCardColor
+    {
+        get => _stackCardColor;
+        set
+        {
+            _stackCardColor = value;
+            RaisePropertyChanged();
+        }
+    }
+
+    public string StackCardColorText
+    {
+        get => _stackCardColor != null ? _stackCardColor.ToArgbHex() : "";
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                StackCardColor = null;
+            }
+            else
+            {
+                var hex = value.StartsWith("#") ? value : "#" + value;
+                try { StackCardColor = Color.FromArgb(hex); }
+                catch { /* ignore invalid color strings */ }
+            }
+            RaisePropertyChanged();
         }
     }
 

--- a/samples/SwipeCardView.Sample/ViewModels/CustomizablePageViewModel.cs
+++ b/samples/SwipeCardView.Sample/ViewModels/CustomizablePageViewModel.cs
@@ -30,6 +30,10 @@ public class CustomizablePageViewModel : BasePageViewModel
 
     private bool _isLoopCards;
 
+    private int _stackDepth;
+    private double _stackOffset;
+    private double _stackScaleStep;
+
     public CustomizablePageViewModel()
     {
         _cardItems = new ObservableCollection<string>();
@@ -54,6 +58,10 @@ public class CustomizablePageViewModel : BasePageViewModel
         _animationLength = 250;
         _backCardScale = 0.8f;
         _cardRotation = 20;
+
+        _stackDepth = 0;
+        _stackOffset = 10;
+        _stackScaleStep = 0.03;
 
         SwipedCommand = new Command<SwipedCardEventArgs>(OnSwipedCommand);
         DraggingCommand = new Command<DraggingCardEventArgs>(OnDraggingCommand);
@@ -226,6 +234,36 @@ public class CustomizablePageViewModel : BasePageViewModel
         set
         {
             _isLoopCards = value;
+            RaisePropertyChanged();
+        }
+    }
+
+    public int StackDepth
+    {
+        get => _stackDepth;
+        set
+        {
+            _stackDepth = value;
+            RaisePropertyChanged();
+        }
+    }
+
+    public double StackOffset
+    {
+        get => _stackOffset;
+        set
+        {
+            _stackOffset = value;
+            RaisePropertyChanged();
+        }
+    }
+
+    public double StackScaleStep
+    {
+        get => _stackScaleStep;
+        set
+        {
+            _stackScaleStep = value;
             RaisePropertyChanged();
         }
     }

--- a/samples/SwipeCardView.Sample/Views/ColorsPage.xaml.cs
+++ b/samples/SwipeCardView.Sample/Views/ColorsPage.xaml.cs
@@ -15,52 +15,53 @@ public partial class ColorsPage : ContentPage
 
     private void OnDragging(object sender, DraggingCardEventArgs e)
     {
-        // Use the card view (the Border with rounded corners) for color feedback,
-        // not the SwipeCardView itself which is a rectangular container.
-        var card = e.CardView ?? (View)sender;
-
         // Update page-level labels (not inside card template) to avoid
         // layout recalculation inside the Frame during Scale transforms,
         // which causes Android rendering artifacts.
         DirectionLabel.Text = e.Direction.ToString();
         PositionLabel.Text = e.Position.ToString();
 
+        // Apply color to the card's Border (rounded corners) instead of
+        // the SwipeCardView container (square corners).
+        var border = GetCardBorder(e.CardView);
+
         switch (e.Position)
         {
             case DraggingCardPosition.Start:
+                SetCardColor(border, Color.FromArgb("#F8F8F8"));
                 break;
 
             case DraggingCardPosition.UnderThreshold:
-                card.BackgroundColor = Colors.DarkTurquoise;
+                SetCardColor(border, Colors.DarkTurquoise);
                 break;
 
             case DraggingCardPosition.OverThreshold:
                 switch (e.Direction)
                 {
                     case SwipeCardDirection.Left:
-                        card.BackgroundColor = Color.FromArgb("#FF6A4F");
+                        SetCardColor(border, Color.FromArgb("#FF6A4F"));
                         break;
 
                     case SwipeCardDirection.Right:
-                        card.BackgroundColor = Color.FromArgb("#63DD99");
+                        SetCardColor(border, Color.FromArgb("#63DD99"));
                         break;
 
                     case SwipeCardDirection.Up:
-                        card.BackgroundColor = Color.FromArgb("#2196F3");
+                        SetCardColor(border, Color.FromArgb("#2196F3"));
                         break;
 
                     case SwipeCardDirection.Down:
-                        card.BackgroundColor = Colors.MediumPurple;
+                        SetCardColor(border, Colors.MediumPurple);
                         break;
                 }
                 break;
 
             case DraggingCardPosition.FinishedUnderThreshold:
-                card.BackgroundColor = Colors.Beige;
+                SetCardColor(border, Color.FromArgb("#F8F8F8"));
                 break;
 
             case DraggingCardPosition.FinishedOverThreshold:
-                card.BackgroundColor = Colors.Beige;
+                SetCardColor(border, Color.FromArgb("#F8F8F8"));
                 DirectionLabel.Text = string.Empty;
                 PositionLabel.Text = string.Empty;
                 break;
@@ -68,6 +69,21 @@ public partial class ColorsPage : ContentPage
             default:
                 throw new ArgumentOutOfRangeException();
         }
+    }
+
+    private static Border? GetCardBorder(View? cardView)
+    {
+        if (cardView is ContentView cv && cv.Content is Border border)
+            return border;
+        if (cardView is Border b)
+            return b;
+        return null;
+    }
+
+    private static void SetCardColor(Border? border, Color color)
+    {
+        if (border != null)
+            border.BackgroundColor = color;
     }
 
     private void OnGoBackClicked(object? sender, EventArgs e)

--- a/samples/SwipeCardView.Sample/Views/CustomizablePage.xaml
+++ b/samples/SwipeCardView.Sample/Views/CustomizablePage.xaml
@@ -27,8 +27,7 @@
             StackDepth="{Binding StackDepth}"
             StackOffset="{Binding StackOffset}"
             StackScaleStep="{Binding StackScaleStep}"
-            StackDirection="{Binding StackDirection}"
-            StackCardColor="{Binding StackCardColor}">
+            StackDirection="{Binding StackDirection}">
             <swipeCardView:SwipeCardView.ItemTemplate>
                 <DataTemplate>
                     <Border StrokeShape="RoundRectangle 16"
@@ -178,10 +177,6 @@
                                 </HorizontalStackLayout>
                             </VerticalStackLayout>
                         </Grid>
-                        <VerticalStackLayout>
-                            <Label Text="Card Color (hex, e.g. #5A7050)" FontSize="10" TextColor="{StaticResource Gray400}" />
-                            <Entry Text="{Binding StackCardColorText}" Placeholder="#RRGGBB" FontSize="14" />
-                        </VerticalStackLayout>
                     </VerticalStackLayout>
                 </Border>
 

--- a/samples/SwipeCardView.Sample/Views/CustomizablePage.xaml
+++ b/samples/SwipeCardView.Sample/Views/CustomizablePage.xaml
@@ -26,7 +26,8 @@
             LoopCards="{Binding IsLoopCards}"
             StackDepth="{Binding StackDepth}"
             StackOffset="{Binding StackOffset}"
-            StackScaleStep="{Binding StackScaleStep}">
+            StackScaleStep="{Binding StackScaleStep}"
+            StackDirection="{Binding StackDirection}">
             <swipeCardView:SwipeCardView.ItemTemplate>
                 <DataTemplate>
                     <Border StrokeShape="RoundRectangle 16"
@@ -154,7 +155,7 @@
                         BackgroundColor="Transparent" Padding="12,8">
                     <VerticalStackLayout Spacing="6">
                         <Label Text="Stack Effect" FontSize="12" FontAttributes="Bold" TextColor="{StaticResource Gray500}" />
-                        <Grid ColumnDefinitions="*,*,*" ColumnSpacing="8">
+                        <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="8">
                             <VerticalStackLayout>
                                 <Label Text="Depth" FontSize="10" TextColor="{StaticResource Gray400}" />
                                 <Entry Text="{Binding StackDepth}" Keyboard="Numeric" FontSize="14" />
@@ -166,6 +167,14 @@
                             <VerticalStackLayout Grid.Column="2">
                                 <Label Text="Scale Step" FontSize="10" TextColor="{StaticResource Gray400}" />
                                 <Entry Text="{Binding StackScaleStep}" Keyboard="Numeric" FontSize="14" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Column="3" VerticalOptions="End">
+                                <Label Text="Direction" FontSize="10" TextColor="{StaticResource Gray400}" />
+                                <HorizontalStackLayout Spacing="4">
+                                    <Label Text="↓" FontSize="14" TextColor="{StaticResource Gray400}" />
+                                    <Switch IsToggled="{Binding IsStackDirectionTop}" />
+                                    <Label Text="↑" FontSize="14" TextColor="{StaticResource Gray400}" />
+                                </HorizontalStackLayout>
                             </VerticalStackLayout>
                         </Grid>
                     </VerticalStackLayout>

--- a/samples/SwipeCardView.Sample/Views/CustomizablePage.xaml
+++ b/samples/SwipeCardView.Sample/Views/CustomizablePage.xaml
@@ -23,7 +23,10 @@
             AnimationLength="{Binding AnimationLength}"
             BackCardScale="{Binding BackCardScale}"
             CardRotation="{Binding CardRotation}"
-            LoopCards="{Binding IsLoopCards}">
+            LoopCards="{Binding IsLoopCards}"
+            StackDepth="{Binding StackDepth}"
+            StackOffset="{Binding StackOffset}"
+            StackScaleStep="{Binding StackScaleStep}">
             <swipeCardView:SwipeCardView.ItemTemplate>
                 <DataTemplate>
                     <Border StrokeShape="RoundRectangle 16"
@@ -145,6 +148,28 @@
                            VerticalOptions="Center" FontSize="12" FontAttributes="Bold"
                            TextColor="{StaticResource Primary}" WidthRequest="36" />
                 </Grid>
+
+                <!-- Stack settings -->
+                <Border StrokeShape="RoundRectangle 12" Stroke="{StaticResource Gray100}"
+                        BackgroundColor="Transparent" Padding="12,8">
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="Stack Effect" FontSize="12" FontAttributes="Bold" TextColor="{StaticResource Gray500}" />
+                        <Grid ColumnDefinitions="*,*,*" ColumnSpacing="8">
+                            <VerticalStackLayout>
+                                <Label Text="Depth" FontSize="10" TextColor="{StaticResource Gray400}" />
+                                <Entry Text="{Binding StackDepth}" Keyboard="Numeric" FontSize="14" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Column="1">
+                                <Label Text="Offset" FontSize="10" TextColor="{StaticResource Gray400}" />
+                                <Entry Text="{Binding StackOffset}" Keyboard="Numeric" FontSize="14" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Column="2">
+                                <Label Text="Scale Step" FontSize="10" TextColor="{StaticResource Gray400}" />
+                                <Entry Text="{Binding StackScaleStep}" Keyboard="Numeric" FontSize="14" />
+                            </VerticalStackLayout>
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
 
                 <!-- Action buttons -->
                 <Grid ColumnDefinitions="*,*" ColumnSpacing="8">

--- a/samples/SwipeCardView.Sample/Views/CustomizablePage.xaml
+++ b/samples/SwipeCardView.Sample/Views/CustomizablePage.xaml
@@ -27,7 +27,8 @@
             StackDepth="{Binding StackDepth}"
             StackOffset="{Binding StackOffset}"
             StackScaleStep="{Binding StackScaleStep}"
-            StackDirection="{Binding StackDirection}">
+            StackDirection="{Binding StackDirection}"
+            StackCardColor="{Binding StackCardColor}">
             <swipeCardView:SwipeCardView.ItemTemplate>
                 <DataTemplate>
                     <Border StrokeShape="RoundRectangle 16"
@@ -177,6 +178,10 @@
                                 </HorizontalStackLayout>
                             </VerticalStackLayout>
                         </Grid>
+                        <VerticalStackLayout>
+                            <Label Text="Card Color (hex, e.g. #5A7050)" FontSize="10" TextColor="{StaticResource Gray400}" />
+                            <Entry Text="{Binding StackCardColorText}" Placeholder="#RRGGBB" FontSize="14" />
+                        </VerticalStackLayout>
                     </VerticalStackLayout>
                 </Border>
 

--- a/samples/SwipeCardView.Sample/Views/TinderPage.xaml
+++ b/samples/SwipeCardView.Sample/Views/TinderPage.xaml
@@ -15,16 +15,19 @@
             ItemsSource="{Binding Profiles}"
             HorizontalOptions="FillAndExpand"
             VerticalOptions="FillAndExpand"
-            Padding="8,4,8,24"
+            Padding="12,32,12,24"
             SwipedCommand="{Binding SwipedCommand}"
             DraggingCommand="{Binding DraggingCommand}"
             Threshold="{Binding Threshold}"
             SupportedSwipeDirections="Left, Right, Up"
             SupportedDraggingDirections="Left, Right, Up, Down"
             LoopCards="True"
-            StackDepth="2"
-            StackOffset="15"
-            BackCardScale="0.95">
+            StackDepth="3"
+            StackOffset="5"
+            StackScaleStep="0"
+            StackDirection="Top"
+            StackCardColor="#5A7050"
+            BackCardScale="0.98">
             <swipeCardView:SwipeCardView.ItemTemplate>
                 <DataTemplate>
                     <Border StrokeShape="RoundRectangle 12"

--- a/samples/SwipeCardView.Sample/Views/TinderPage.xaml
+++ b/samples/SwipeCardView.Sample/Views/TinderPage.xaml
@@ -15,13 +15,16 @@
             ItemsSource="{Binding Profiles}"
             HorizontalOptions="FillAndExpand"
             VerticalOptions="FillAndExpand"
-            Padding="8,4,8,0"
+            Padding="8,4,8,24"
             SwipedCommand="{Binding SwipedCommand}"
             DraggingCommand="{Binding DraggingCommand}"
             Threshold="{Binding Threshold}"
             SupportedSwipeDirections="Left, Right, Up"
             SupportedDraggingDirections="Left, Right, Up, Down"
-            LoopCards="True">
+            LoopCards="True"
+            StackDepth="2"
+            StackOffset="15"
+            BackCardScale="0.95">
             <swipeCardView:SwipeCardView.ItemTemplate>
                 <DataTemplate>
                     <Border StrokeShape="RoundRectangle 12"

--- a/samples/SwipeCardView.Sample/Views/TinderPage.xaml
+++ b/samples/SwipeCardView.Sample/Views/TinderPage.xaml
@@ -26,7 +26,6 @@
             StackOffset="5"
             StackScaleStep="0"
             StackDirection="Top"
-            StackCardColor="#5A7050"
             BackCardScale="0.98">
             <swipeCardView:SwipeCardView.ItemTemplate>
                 <DataTemplate>

--- a/samples/SwipeCardView.Sample/Views/TinderPage.xaml
+++ b/samples/SwipeCardView.Sample/Views/TinderPage.xaml
@@ -23,7 +23,7 @@
             SupportedDraggingDirections="Left, Right, Up, Down"
             LoopCards="True"
             StackDepth="3"
-            StackOffset="5"
+            StackOffset="8"
             StackScaleStep="0"
             StackDirection="Top"
             BackCardScale="0.98">

--- a/src/Plugin.Maui.SwipeCardView/Core/StackDirection.cs
+++ b/src/Plugin.Maui.SwipeCardView/Core/StackDirection.cs
@@ -1,0 +1,13 @@
+namespace Plugin.Maui.SwipeCardView.Core;
+
+/// <summary>
+/// Determines the direction in which stacked cards peek behind the top card.
+/// </summary>
+public enum StackDirection
+{
+    /// <summary>Back cards peek below the top card.</summary>
+    Bottom,
+
+    /// <summary>Back cards peek above the top card.</summary>
+    Top
+}

--- a/src/Plugin.Maui.SwipeCardView/Plugin.Maui.SwipeCardView.csproj
+++ b/src/Plugin.Maui.SwipeCardView/Plugin.Maui.SwipeCardView.csproj
@@ -9,7 +9,7 @@
 		<UseMaui>true</UseMaui>
 
 		<!-- Version: overridden by CI via -p:PackageVersion=X.Y.Z -->
-		<Version>1.0.1</Version>
+		<Version>1.1.0</Version>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -92,7 +92,8 @@ public class SwipeCardView : ContentView, IDisposable
             typeof(float),
             typeof(SwipeCardView),
             DefaultBackCardScale,
-            validateValue: (_, value) => value is float f && f > 0f && f <= 1f);
+            validateValue: (_, value) => value is float f && f > 0f && f <= 1f,
+            propertyChanged: OnStackVisualPropertyChanged);
 
     public static readonly BindableProperty CardRotationProperty =
         BindableProperty.Create(
@@ -130,7 +131,8 @@ public class SwipeCardView : ContentView, IDisposable
             typeof(double),
             typeof(SwipeCardView),
             10.0,
-            validateValue: (_, value) => value is double d && d >= 0);
+            validateValue: (_, value) => value is double d && d >= 0,
+            propertyChanged: OnStackVisualPropertyChanged);
 
     public static readonly BindableProperty StackScaleStepProperty =
         BindableProperty.Create(
@@ -138,7 +140,16 @@ public class SwipeCardView : ContentView, IDisposable
             typeof(double),
             typeof(SwipeCardView),
             0.03,
-            validateValue: (_, value) => value is double d && d >= 0 && d <= 0.5);
+            validateValue: (_, value) => value is double d && d >= 0 && d <= 0.5,
+            propertyChanged: OnStackVisualPropertyChanged);
+
+    public static readonly BindableProperty StackDirectionProperty =
+        BindableProperty.Create(
+            nameof(StackDirection),
+            typeof(StackDirection),
+            typeof(SwipeCardView),
+            Core.StackDirection.Bottom,
+            propertyChanged: OnStackVisualPropertyChanged);
 
     #endregion Bindable Properties
 
@@ -337,6 +348,13 @@ public class SwipeCardView : ContentView, IDisposable
     {
         get => (double)GetValue(StackScaleStepProperty);
         set => SetValue(StackScaleStepProperty, value);
+    }
+
+    /// <summary>Gets or sets whether stacked cards peek above or below the top card. Default is Bottom.</summary>
+    public StackDirection StackDirection
+    {
+        get => (StackDirection)GetValue(StackDirectionProperty);
+        set => SetValue(StackDirectionProperty, value);
     }
 
     #endregion Public Properties
@@ -796,6 +814,14 @@ public class SwipeCardView : ContentView, IDisposable
     {
         var swipeCardView = (SwipeCardView)bindable;
         swipeCardView.RebuildShadowCards();
+        swipeCardView.ApplyStackVisuals();
+        swipeCardView.PositionShadowCards();
+    }
+
+    private static void OnStackVisualPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        var swipeCardView = (SwipeCardView)bindable;
+        swipeCardView.ApplyStackVisuals();
         swipeCardView.PositionShadowCards();
     }
 
@@ -846,6 +872,8 @@ public class SwipeCardView : ContentView, IDisposable
         var refHeight = _cards[PrevCardIndex(_topCardIndex)]?.Height ?? Height;
         if (refHeight <= 0) refHeight = Height;
 
+        var dirSign = StackDirection == Core.StackDirection.Top ? -1.0 : 1.0;
+
         for (int i = 0; i < _shadowCards.Count; i++)
         {
             var shadow = _shadowCards[i];
@@ -854,7 +882,7 @@ public class SwipeCardView : ContentView, IDisposable
             var compensation = refHeight * (1.0 - scale) / 2.0;
             shadow.AnchorY = 0.5;
             shadow.Scale = scale;
-            shadow.TranslationY = (i + 2) * StackOffset + compensation;
+            shadow.TranslationY = dirSign * ((i + 2) * StackOffset + compensation);
             shadow.IsVisible = hasItems;
         }
     }
@@ -869,6 +897,8 @@ public class SwipeCardView : ContentView, IDisposable
         var refHeight = _cards[PrevCardIndex(_topCardIndex)]?.Height ?? Height;
         if (refHeight <= 0) refHeight = Height;
 
+        var dirSign = StackDirection == Core.StackDirection.Top ? -1.0 : 1.0;
+
         for (int i = 0; i < _shadowCards.Count; i++)
         {
             // Shadow i animates from depth (i+2) toward depth (i+1).
@@ -879,7 +909,7 @@ public class SwipeCardView : ContentView, IDisposable
             var targetTY = restTY - (progressRatio * StackOffset);
 
             _shadowCards[i].Scale = targetScale;
-            _shadowCards[i].TranslationY = targetTY + compensation;
+            _shadowCards[i].TranslationY = dirSign * (targetTY + compensation);
         }
     }
 
@@ -966,15 +996,23 @@ public class SwipeCardView : ContentView, IDisposable
 
     /// <summary>Computes the TranslationY needed for a back card to peek by the desired offset.</summary>
     /// <remarks>
-    /// With center-anchored scaling (AnchorY=0.5), a scaled card's bottom edge retracts by
-    /// H*(1-Scale)/2. To produce a visible peek of <paramref name="peekAmount"/> dp,
-    /// the total TranslationY must compensate for this retraction.
+    /// With center-anchored scaling (AnchorY=0.5), a scaled card's edges retract by H*(1-Scale)/2.
+    /// For Bottom direction, we compensate the bottom retraction so the card peeks below.
+    /// For Top direction, we compensate the top retraction so the card peeks above.
     /// </remarks>
     private double ComputeStackTranslationY(View card, double scale, double peekAmount)
     {
         var height = card.Height;
         if (height <= 0) height = Height; // fallback to container height
         var compensation = height * (1.0 - scale) / 2.0;
+
+        if (StackDirection == Core.StackDirection.Top)
+        {
+            // Peek above: negative offset, subtract compensation (top edge retracts inward)
+            return -card.Y - peekAmount - compensation;
+        }
+
+        // Peek below: positive offset, add compensation (bottom edge retracts inward)
         return -card.Y + peekAmount + compensation;
     }
 

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -300,8 +300,8 @@ public class SwipeCardView : ContentView, IDisposable
     }
 
     /// <summary>Gets or sets the initial scale of the back card (0.0–1.0). Scales up to 1.0 as the top card is dragged.
-    /// When <see cref="StackDepth"/> &gt; 1, this is the scale of the first back card; successive shadow cards
-    /// scale down further by <see cref="StackScaleStep"/> each. Default is 0.8.</summary>
+    /// Only used in non-stack mode (<see cref="StackDepth"/> = 0). In stack mode, card scaling is
+    /// controlled by <see cref="StackScaleStep"/> instead. Default is 0.8.</summary>
     public float BackCardScale
     {
         get => (float)GetValue(BackCardScaleProperty);
@@ -395,7 +395,7 @@ public class SwipeCardView : ContentView, IDisposable
 
         foreach (var shadow in _shadowCards)
         {
-            (shadow as IDisposable)?.Dispose();
+            // Border doesn't implement IDisposable; removal from Children is sufficient.
         }
         _shadowCards.Clear();
 
@@ -553,7 +553,10 @@ public class SwipeCardView : ContentView, IDisposable
         swipeCardView.Content = null;
 
         var view = new Grid() { IsClippedToBounds = false };
-        DisableNativeClipping(view);
+        if (swipeCardView.StackDepth > 0)
+        {
+            DisableNativeClipping(view);
+        }
 
         // create a stack of cards
         for (var i = NumCards - 1; i >= 0; i--)
@@ -606,6 +609,11 @@ public class SwipeCardView : ContentView, IDisposable
                     Microsoft.Maui.Controls.ViewExtensions.CancelAnimations(card);
                     card.IsVisible = false;
                 }
+            }
+            // Hide shadow cards too
+            foreach (var shadow in swipeCardView._shadowCards)
+            {
+                shadow.IsVisible = false;
             }
             swipeCardView.TopItem = null;
             swipeCardView.PreviousItem = null;
@@ -705,7 +713,7 @@ public class SwipeCardView : ContentView, IDisposable
             case NotifyCollectionChangedAction.Remove:
                 if (ItemsSource == null || ItemsSource.Count == 0)
                 {
-                    // All items removed — hide cards
+                    // All items removed — hide cards and shadow cards
                     foreach (var card in _cards)
                     {
                         if (card != null)
@@ -713,6 +721,10 @@ public class SwipeCardView : ContentView, IDisposable
                             Microsoft.Maui.Controls.ViewExtensions.CancelAnimations(card);
                             card.IsVisible = false;
                         }
+                    }
+                    foreach (var shadow in _shadowCards)
+                    {
+                        shadow.IsVisible = false;
                     }
                     _itemIndex = 0;
                     _currentDisplayIndex = 0;
@@ -815,7 +827,21 @@ public class SwipeCardView : ContentView, IDisposable
     {
         var swipeCardView = (SwipeCardView)bindable;
         swipeCardView.RebuildShadowCards();
-        swipeCardView.ApplyStackVisuals();
+
+        if (newValue is int depth && depth <= 0)
+        {
+            // Stack mode disabled — restore non-stack back card state (hidden)
+            var backCard = swipeCardView._cards[swipeCardView.PrevCardIndex(swipeCardView._topCardIndex)];
+            if (backCard != null)
+            {
+                backCard.Opacity = 0;
+                backCard.Scale = 1.0;
+            }
+        }
+        else
+        {
+            swipeCardView.ApplyStackVisuals();
+        }
         swipeCardView.PositionShadowCards();
     }
 
@@ -863,11 +889,18 @@ public class SwipeCardView : ContentView, IDisposable
         foreach (var shadow in _shadowCards)
         {
             grid.Children.Remove(shadow);
-            (shadow as IDisposable)?.Dispose();
         }
         _shadowCards.Clear();
 
-        if (StackDepth <= 0) return;
+        if (StackDepth <= 0)
+        {
+            grid.IsClippedToBounds = true;
+            return;
+        }
+
+        // Disable clipping so shadow cards can extend beyond bounds
+        grid.IsClippedToBounds = false;
+        DisableNativeClipping(grid);
 
         // Create shadow cards for all stack depths (deepest → shallowest) so they are
         // earliest in Children and render behind everything at the same ZIndex.
@@ -934,7 +967,7 @@ public class SwipeCardView : ContentView, IDisposable
         if (Content is not Grid grid) return;
         if (_shadowCards.Count == 0) return;
 
-        var hasItems = ItemsSource != null && ItemsSource.Count > 0;
+        var hasItems = ItemsSource != null && ItemsSource.Count >= 2;
 
         // Use the internal grid height (excludes SwipeCardView padding) for
         // more accurate compensation when element heights aren't available yet.
@@ -1031,28 +1064,6 @@ public class SwipeCardView : ContentView, IDisposable
         }
 
         PositionShadowCards();
-    }
-
-    /// <summary>Computes the TranslationY needed for a back card to peek by the desired offset.</summary>
-    /// <remarks>
-    /// With center-anchored scaling (AnchorY=0.5), a scaled card's edges retract by H*(1-Scale)/2.
-    /// For Bottom direction, we compensate the bottom retraction so the card peeks below.
-    /// For Top direction, we compensate the top retraction so the card peeks above.
-    /// </remarks>
-    private double ComputeStackTranslationY(View card, double scale, double peekAmount)
-    {
-        var height = card.Height;
-        if (height <= 0) height = Height; // fallback to container height
-        var compensation = height * (1.0 - scale) / 2.0;
-
-        if (StackDirection == Core.StackDirection.Top)
-        {
-            // Peek above: negative offset, subtract compensation (top edge retracts inward)
-            return -card.Y - peekAmount - compensation;
-        }
-
-        // Peek below: positive offset, add compensation (bottom edge retracts inward)
-        return -card.Y + peekAmount + compensation;
     }
 
     /// <summary>Applies visual transforms for the stack effect (called after layout pass).</summary>

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -151,14 +151,6 @@ public class SwipeCardView : ContentView, IDisposable
             Core.StackDirection.Bottom,
             propertyChanged: OnStackVisualPropertyChanged);
 
-    public static readonly BindableProperty StackCardColorProperty =
-        BindableProperty.Create(
-            nameof(StackCardColor),
-            typeof(Color),
-            typeof(SwipeCardView),
-            null,
-            propertyChanged: OnStackCardColorPropertyChanged);
-
     #endregion Bindable Properties
 
     #region Constants
@@ -206,7 +198,6 @@ public class SwipeCardView : ContentView, IDisposable
     private int _collectionVersion = 0;
     private INotifyCollectionChanged? _subscribedCollection;
     private readonly List<Border> _shadowCards = new();
-    private Border? _backCardOverlay;
 
     #endregion Private fields
 
@@ -366,13 +357,6 @@ public class SwipeCardView : ContentView, IDisposable
         set => SetValue(StackDirectionProperty, value);
     }
 
-    /// <summary>Gets or sets the background color of decorative shadow cards in the stack. Default is White.</summary>
-    public Color? StackCardColor
-    {
-        get => (Color?)GetValue(StackCardColorProperty);
-        set => SetValue(StackCardColorProperty, value);
-    }
-
     #endregion Public Properties
 
     #region Public Methods
@@ -414,12 +398,6 @@ public class SwipeCardView : ContentView, IDisposable
             (shadow as IDisposable)?.Dispose();
         }
         _shadowCards.Clear();
-
-        if (_backCardOverlay != null)
-        {
-            (_backCardOverlay as IDisposable)?.Dispose();
-            _backCardOverlay = null;
-        }
 
         SizeChanged -= OnSizeChangedForStack;
 
@@ -848,22 +826,6 @@ public class SwipeCardView : ContentView, IDisposable
         swipeCardView.PositionShadowCards();
     }
 
-    private static void OnStackCardColorPropertyChanged(BindableObject bindable, object oldValue, object newValue)
-    {
-        var swipeCardView = (SwipeCardView)bindable;
-
-        // Rebuild overlay when StackCardColor changes (null ↔ non-null affects overlay existence)
-        if ((oldValue == null) != (newValue == null))
-        {
-            swipeCardView.RebuildShadowCards();
-            swipeCardView.PositionShadowCards();
-        }
-        else
-        {
-            swipeCardView.ApplyGraduatedColors();
-        }
-    }
-
     /// <summary>
     /// Disables native clipping on a Grid so that shadow cards can extend beyond its bounds.
     /// On Android, ViewGroup clips children by default; this explicitly disables it.
@@ -892,59 +854,6 @@ public class SwipeCardView : ContentView, IDisposable
 #endif
     }
 
-    /// <summary>Blends a color toward white by the given factor (0 = unchanged, 1 = white).</summary>
-    private static Color GraduateColor(Color baseColor, double blendFactor)
-    {
-        blendFactor = Math.Clamp(blendFactor, 0, 1);
-        return new Color(
-            (float)(baseColor.Red + (1.0 - baseColor.Red) * blendFactor),
-            (float)(baseColor.Green + (1.0 - baseColor.Green) * blendFactor),
-            (float)(baseColor.Blue + (1.0 - baseColor.Blue) * blendFactor),
-            baseColor.Alpha);
-    }
-
-    /// <summary>Computes a thin stroke color slightly darker than the given fill.</summary>
-    private static Color StrokeColorFor(Color fillColor)
-    {
-        const double darkenFactor = 0.15;
-        return new Color(
-            (float)(fillColor.Red * (1 - darkenFactor)),
-            (float)(fillColor.Green * (1 - darkenFactor)),
-            (float)(fillColor.Blue * (1 - darkenFactor)),
-            fillColor.Alpha);
-    }
-
-    /// <summary>Applies graduated colors to overlay and shadow cards for visual depth.</summary>
-    private void ApplyGraduatedColors()
-    {
-        var baseColor = StackCardColor ?? Colors.White;
-        int totalLayers = StackDepth;
-        if (totalLayers < 1) totalLayers = 1;
-
-        // Layer 0 = overlay (closest to card, darkest).
-        // No stroke so the fill covers the back card edge-to-edge.
-        if (_backCardOverlay != null)
-        {
-            _backCardOverlay.BackgroundColor = baseColor;
-            _backCardOverlay.Stroke = null;
-            _backCardOverlay.StrokeThickness = 0;
-        }
-
-        // Shadow cards get progressively lighter so each strip is clearly
-        // distinguishable.  High maxBlend creates strong contrast between the
-        // closest strip (base color) and the farthest strip (almost white).
-        const double maxBlend = 0.95;
-        for (int i = 0; i < _shadowCards.Count; i++)
-        {
-            double t = (double)(i + 1) / totalLayers;
-            double blendFactor = t * maxBlend;
-            var layerColor = GraduateColor(baseColor, blendFactor);
-            _shadowCards[i].BackgroundColor = layerColor;
-            _shadowCards[i].Stroke = null;
-            _shadowCards[i].StrokeThickness = 0;
-        }
-    }
-
     /// <summary>Creates or removes decorative Border elements for the stack visual effect.</summary>
     private void RebuildShadowCards()
     {
@@ -958,67 +867,28 @@ public class SwipeCardView : ContentView, IDisposable
         }
         _shadowCards.Clear();
 
-        // Remove existing back card overlay
-        if (_backCardOverlay != null)
-        {
-            grid.Children.Remove(_backCardOverlay);
-            (_backCardOverlay as IDisposable)?.Dispose();
-            _backCardOverlay = null;
-        }
-
-        if (StackDepth <= 1 && StackCardColor == null) return;
-
-        var baseColor = StackCardColor ?? Colors.White;
-        int totalLayers = Math.Max(StackDepth, 1);
+        if (StackDepth <= 1) return;
 
         // Create shadow cards FIRST (deepest → shallowest) so they are earliest in Children
         // and render behind everything at the same ZIndex.
-        if (StackDepth > 1)
+        int shadowCount = StackDepth - 1;
+        // Insert deepest shadow first (it renders furthest back)
+        for (int i = shadowCount - 1; i >= 0; i--)
         {
-            int shadowCount = StackDepth - 1;
-            // Insert deepest shadow first (it renders furthest back)
-            for (int i = shadowCount - 1; i >= 0; i--)
+            var shadow = new Border
             {
-                double t = (double)(i + 1) / totalLayers;
-                double blendFactor = t * 0.95;
-                var layerColor = GraduateColor(baseColor, blendFactor);
-                var shadow = new Border
-                {
-                    BackgroundColor = layerColor,
-                    Stroke = null,
-                    StrokeThickness = 0,
-                    StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle { CornerRadius = new CornerRadius(12) },
-                    ZIndex = -(i + 1),
-                    InputTransparent = true,
-                    IsVisible = false,
-                    HorizontalOptions = LayoutOptions.Fill,
-                    VerticalOptions = LayoutOptions.Fill,
-                };
-                _shadowCards.Insert(0, shadow);
-                grid.Children.Insert(0, shadow);
-            }
-        }
-
-        // When StackCardColor is set, create an overlay that covers the back card.
-        // Inserted AFTER shadows but BEFORE cards in the children order.
-        if (StackCardColor != null && StackDepth > 0)
-        {
-            _backCardOverlay = new Border
-            {
-                BackgroundColor = baseColor,
-                Stroke = null,
-                StrokeThickness = 0,
+                BackgroundColor = Colors.White,
+                Stroke = new SolidColorBrush(Color.FromArgb("#E0E0E0")),
+                StrokeThickness = 1,
                 StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle { CornerRadius = new CornerRadius(12) },
-                ZIndex = 0,
+                ZIndex = -(i + 1),
                 InputTransparent = true,
                 IsVisible = false,
                 HorizontalOptions = LayoutOptions.Fill,
                 VerticalOptions = LayoutOptions.Fill,
             };
-            // Append AFTER the real cards so the overlay renders on top of the
-            // back card (later child at the same ZIndex wins) while the front card
-            // with ZIndex=1 still renders above everything.
-            grid.Children.Add(_backCardOverlay);
+            _shadowCards.Insert(0, shadow);
+            grid.Children.Insert(0, shadow);
         }
     }
 
@@ -1059,6 +929,7 @@ public class SwipeCardView : ContentView, IDisposable
     private void PositionShadowCards()
     {
         if (Content is not Grid grid) return;
+        if (_shadowCards.Count == 0) return;
 
         var hasItems = ItemsSource != null && ItemsSource.Count > 0;
 
@@ -1066,21 +937,10 @@ public class SwipeCardView : ContentView, IDisposable
         // more accurate compensation when element heights aren't available yet.
         var fallbackHeight = grid.Height > 0 ? grid.Height : Height;
 
-        // Position the back card overlay (depth 1) using its OWN layout position
-        if (_backCardOverlay != null)
-        {
-            var overlayH = _backCardOverlay.Height > 0 ? _backCardOverlay.Height : fallbackHeight;
-            _backCardOverlay.Scale = LayerScale(1);
-            _backCardOverlay.TranslationY = LayerTranslationY(1, _backCardOverlay.Y, overlayH);
-            _backCardOverlay.IsVisible = hasItems;
-        }
-
-        if (_shadowCards.Count == 0) return;
-
         for (int i = 0; i < _shadowCards.Count; i++)
         {
             var shadow = _shadowCards[i];
-            int depth = i + 2; // overlay is depth 1, shadows start at depth 2
+            int depth = i + 2; // back card is depth 1, shadows start at depth 2
             var shadowH = shadow.Height > 0 ? shadow.Height : fallbackHeight;
             shadow.Scale = LayerScale(depth);
             shadow.TranslationY = LayerTranslationY(depth, shadow.Y, shadowH);
@@ -1220,14 +1080,6 @@ public class SwipeCardView : ContentView, IDisposable
         backCard.Opacity = 1;
         backCard.TranslationY = ComputeStackTranslationY(backCard, stackScale, StackOffset);
 
-        // Position overlay to exactly match the back card so it covers it fully.
-        if (_backCardOverlay != null)
-        {
-            _backCardOverlay.Scale = stackScale;
-            _backCardOverlay.TranslationY = backCard.TranslationY;
-            _backCardOverlay.IsVisible = true;
-        }
-
         // Reposition shadow cards now that layout has computed correct heights.
         // The initial PositionShadowCards() in Setup() may have used incorrect
         // height fallbacks before elements were laid out.
@@ -1364,14 +1216,6 @@ public class SwipeCardView : ContentView, IDisposable
                 var stackY = ComputeStackTranslationY(backCard, stackScale, StackOffset);
                 backCard.TranslationY = stackY + progress * (homeY - stackY);
 
-                // Overlay tracks back card exactly (fading as it goes)
-                if (_backCardOverlay != null)
-                {
-                    _backCardOverlay.Opacity = 1.0 - progress;
-                    _backCardOverlay.Scale = backCard.Scale;
-                    _backCardOverlay.TranslationY = backCard.TranslationY;
-                }
-
                 // Advance shadow cards one level closer
                 for (int i = 0; i < _shadowCards.Count; i++)
                 {
@@ -1456,13 +1300,6 @@ public class SwipeCardView : ContentView, IDisposable
                 backCard.AnchorY = 0.5;
                 InvalidateCardLayout(backCard);
 
-                // Hide overlay before the back card transitions to new top card
-                if (_backCardOverlay != null)
-                {
-                    _backCardOverlay.IsVisible = false;
-                    _backCardOverlay.Opacity = 1.0; // reset for next card
-                }
-
                 // State transition must happen regardless of animation success
                 topCard.IsVisible = false;
                 topCard.Scale = 0.0;
@@ -1503,23 +1340,13 @@ public class SwipeCardView : ContentView, IDisposable
                     }
                     else
                     {
-                        // Stack mode: animate back card + overlay back to rest positions
+                        // Stack mode: animate back card back to rest positions
                         var stackScale = LayerScale(1);
                         var stackY = ComputeStackTranslationY(prevCard, stackScale, StackOffset);
                         var backScaleTask = prevCard.ScaleToAsync(stackScale, AnimationLength, Easing.SpringOut);
                         var backTranslateTask = prevCard.TranslateToAsync(0, stackY, AnimationLength, Easing.SpringOut);
 
-                        if (_backCardOverlay != null)
-                        {
-                            var overlayFadeTask = _backCardOverlay.FadeToAsync(1.0, AnimationLength);
-                            var overlayScaleTask = _backCardOverlay.ScaleToAsync(stackScale, AnimationLength, Easing.SpringOut);
-                            var overlayTranslateTask = _backCardOverlay.TranslateToAsync(0, stackY, AnimationLength, Easing.SpringOut);
-                            await Task.WhenAll(translateTask, rotateTask, backScaleTask, backTranslateTask, overlayFadeTask, overlayScaleTask, overlayTranslateTask);
-                        }
-                        else
-                        {
-                            await Task.WhenAll(translateTask, rotateTask, backScaleTask, backTranslateTask);
-                        }
+                        await Task.WhenAll(translateTask, rotateTask, backScaleTask, backTranslateTask);
 
                         // Reset shadow cards to rest positions
                         PositionShadowCards();
@@ -1537,20 +1364,13 @@ public class SwipeCardView : ContentView, IDisposable
                 // After the visible animation completes, reset the back card.
                 if (StackDepth > 0)
                 {
-                    // Stack mode: restore back card and overlay to rest state.
+                    // Stack mode: restore back card to rest state.
                     var restScale = LayerScale(1);
-                    if (_backCardOverlay != null)
-                    {
-                        _backCardOverlay.Opacity = 1.0;
-                        _backCardOverlay.Scale = restScale;
-                    }
 
                     prevCard.Opacity = 1;
                     prevCard.AnchorY = 0.5;
                     prevCard.Scale = restScale;
                     prevCard.TranslationY = ComputeStackTranslationY(prevCard, restScale, StackOffset);
-                    if (_backCardOverlay != null)
-                        _backCardOverlay.TranslationY = prevCard.TranslationY;
                 }
                 else
                 {
@@ -1648,15 +1468,6 @@ public class SwipeCardView : ContentView, IDisposable
                 oldTopCard.Opacity = 1;
                 oldTopCard.Scale = stackScale;
                 oldTopCard.TranslationY = ComputeStackTranslationY(oldTopCard, stackScale, StackOffset);
-
-                // Position overlay to match back card exactly
-                if (_backCardOverlay != null)
-                {
-                    _backCardOverlay.Scale = stackScale;
-                    _backCardOverlay.TranslationY = oldTopCard.TranslationY;
-                    _backCardOverlay.IsVisible = true;
-                    _backCardOverlay.Opacity = 1.0;
-                }
             }
             else
             {
@@ -1779,16 +1590,6 @@ public class SwipeCardView : ContentView, IDisposable
         PreviousItem = _currentDisplayIndex >= 1 ? ItemsSource[_currentDisplayIndex - 1] : null;
 
         ResetShadowCards();
-
-        // Position overlay to match the new back card
-        if (_backCardOverlay != null && StackDepth > 0)
-        {
-            var stackScale = LayerScale(1);
-            _backCardOverlay.Scale = stackScale;
-            _backCardOverlay.TranslationY = oldTopCard.TranslationY;
-            _backCardOverlay.Opacity = 1.0;
-            _backCardOverlay.IsVisible = true;
-        }
 
         // Force layout recalculation
         try

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -696,7 +696,7 @@ public class SwipeCardView : ContentView, IDisposable
                     backCard.TranslationX = 0;
                     backCard.TranslationY = -backCard.Y;
                     backCard.ZIndex = 0;
-                    backCard.Opacity = 0;
+                    backCard.Opacity = StackDepth > 0 ? 1 : 0;
                     backCard.IsVisible = true;
                     _itemIndex++;
                 }
@@ -871,8 +871,9 @@ public class SwipeCardView : ContentView, IDisposable
 
         // Create shadow cards for all stack depths (deepest → shallowest) so they are
         // earliest in Children and render behind everything at the same ZIndex.
-        // The back card is kept hidden (Opacity=0) at home position — shadow cards
-        // provide ALL the visual strips behind the top card.
+        // The back card is kept visible (Opacity=1) at home position — it sits behind
+        // the top card and is revealed as the user swipes. Shadow cards provide the
+        // decorative strips behind both cards.
         int shadowCount = StackDepth;
         // Insert deepest shadow first (it renders furthest back)
         for (int i = shadowCount - 1; i >= 0; i--)
@@ -1067,8 +1068,14 @@ public class SwipeCardView : ContentView, IDisposable
             return;
         }
 
-        // Back card stays hidden at home position (Opacity=0, Scale=1.0).
-        // Shadow cards provide all the visual strips behind the top card.
+        // Back card sits at home position (Opacity=1, Scale=1.0) behind the top card.
+        // It is revealed naturally as the user swipes the top card away.
+        // Shadow cards provide the decorative strips behind both cards.
+        var backCard = _cards[PrevCardIndex(_topCardIndex)];
+        if (backCard != null)
+        {
+            backCard.Opacity = 1;
+        }
         PositionShadowCards();
     }
 
@@ -1310,8 +1317,8 @@ public class SwipeCardView : ContentView, IDisposable
                 // After the visible animation completes, reset the back card.
                 if (StackDepth > 0)
                 {
-                    // Stack mode: back card stays hidden at home position.
-                    prevCard.Opacity = 0;
+                    // Stack mode: back card stays visible at home position.
+                    prevCard.Opacity = 1;
                     prevCard.Scale = 1.0;
                     InvalidateCardLayout(prevCard);
                 }
@@ -1408,7 +1415,7 @@ public class SwipeCardView : ContentView, IDisposable
                 // Stack mode: hide back card at home position.
                 // Shadow cards provide the visual strips behind the top card.
                 oldTopCard.AnchorY = 0.5;
-                oldTopCard.Opacity = 0;
+                oldTopCard.Opacity = 1;
             }
             else
             {
@@ -1485,7 +1492,7 @@ public class SwipeCardView : ContentView, IDisposable
                 oldTopCard.BatchBegin();
                 oldTopCard.AnchorY = 0.5;
                 oldTopCard.Scale = 1.0;
-                oldTopCard.Opacity = 0;
+                oldTopCard.Opacity = StackDepth > 0 ? 1 : 0;
                 oldTopCard.BatchCommit();
             }
             finally
@@ -1512,7 +1519,7 @@ public class SwipeCardView : ContentView, IDisposable
             oldTopCard.BatchBegin();
             oldTopCard.AnchorY = 0.5;
             oldTopCard.Scale = 1.0;
-            oldTopCard.Opacity = 0;
+            oldTopCard.Opacity = StackDepth > 0 ? 1 : 0;
             oldTopCard.BatchCommit();
         }
 

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -867,11 +867,13 @@ public class SwipeCardView : ContentView, IDisposable
         }
         _shadowCards.Clear();
 
-        if (StackDepth <= 1) return;
+        if (StackDepth <= 0) return;
 
-        // Create shadow cards FIRST (deepest → shallowest) so they are earliest in Children
-        // and render behind everything at the same ZIndex.
-        int shadowCount = StackDepth - 1;
+        // Create shadow cards for all stack depths (deepest → shallowest) so they are
+        // earliest in Children and render behind everything at the same ZIndex.
+        // The back card is kept hidden (Opacity=0) at home position — shadow cards
+        // provide ALL the visual strips behind the top card.
+        int shadowCount = StackDepth;
         // Insert deepest shadow first (it renders furthest back)
         for (int i = shadowCount - 1; i >= 0; i--)
         {
@@ -940,7 +942,7 @@ public class SwipeCardView : ContentView, IDisposable
         for (int i = 0; i < _shadowCards.Count; i++)
         {
             var shadow = _shadowCards[i];
-            int depth = i + 2; // back card is depth 1, shadows start at depth 2
+            int depth = i + 1; // shadow cards represent depths 1, 2, 3, ...
             var shadowH = shadow.Height > 0 ? shadow.Height : fallbackHeight;
             shadow.Scale = LayerScale(depth);
             shadow.TranslationY = LayerTranslationY(depth, shadow.Y, shadowH);
@@ -1057,32 +1059,16 @@ public class SwipeCardView : ContentView, IDisposable
     {
         if (StackDepth <= 0 || ItemsSource == null || ItemsSource.Count < 2) return;
 
-        var backCard = _cards[PrevCardIndex(_topCardIndex)];
-        if (backCard == null || !backCard.IsVisible) return;
-
-        // We need the card height (or container height) for compensation.
-        // If neither is available yet (first layout pass), subscribe to SizeChanged.
-        var refHeight = backCard.Height > 0 ? backCard.Height : Height;
-        if (refHeight <= 0)
+        // We need height available for compensation math.
+        if (Height <= 0)
         {
-            // Heights not ready — defer until layout completes
             SizeChanged -= OnSizeChangedForStack;
             SizeChanged += OnSizeChangedForStack;
             return;
         }
 
-        // Center-anchored scaling with compensated TranslationY:
-        // The card is scaled from its center (AnchorY=0.5), then pushed enough
-        // that its edge peeks exactly StackOffset dp beyond the top card.
-        var stackScale = LayerScale(1);
-        backCard.AnchorY = 0.5;
-        backCard.Scale = stackScale;
-        backCard.Opacity = 1;
-        backCard.TranslationY = ComputeStackTranslationY(backCard, stackScale, StackOffset);
-
-        // Reposition shadow cards now that layout has computed correct heights.
-        // The initial PositionShadowCards() in Setup() may have used incorrect
-        // height fallbacks before elements were laid out.
+        // Back card stays hidden at home position (Opacity=0, Scale=1.0).
+        // Shadow cards provide all the visual strips behind the top card.
         PositionShadowCards();
     }
 
@@ -1092,7 +1078,6 @@ public class SwipeCardView : ContentView, IDisposable
         {
             SizeChanged -= OnSizeChangedForStack;
             ApplyStackVisuals();
-            PositionShadowCards();
         }
     }
 
@@ -1199,39 +1184,8 @@ public class SwipeCardView : ContentView, IDisposable
                 var newScale = Math.Min(BackCardScale + Math.Abs((cardDistance / Threshold) * (1.0f - BackCardScale)), 1.0f);
                 backCard.Scale = newScale;
             }
-            else
-            {
-                // Stack mode: progressively reveal back card photo as top card drags away.
-                // The overlay fades out and the back card scales/translates toward its
-                // "new top card" position, creating a smooth transition.
-                var distance = Math.Max(Math.Abs(differenceX), Math.Abs(differenceY));
-                var progress = Math.Clamp(distance / Threshold, 0, 1);
-                var stackScale = LayerScale(1);
-
-                // Scale back card from stack scale toward 1.0
-                backCard.Scale = stackScale + progress * (1.0 - stackScale);
-
-                // Translate back card from stack offset toward home position
-                var homeY = -backCard.Y;
-                var stackY = ComputeStackTranslationY(backCard, stackScale, StackOffset);
-                backCard.TranslationY = stackY + progress * (homeY - stackY);
-
-                // Advance shadow cards one level closer
-                for (int i = 0; i < _shadowCards.Count; i++)
-                {
-                    var shadow = _shadowCards[i];
-                    int depth = i + 2;
-                    int targetDepth = depth - 1;
-                    var currentScale = LayerScale(depth);
-                    var targetScale = LayerScale(targetDepth);
-                    shadow.Scale = currentScale + progress * (targetScale - currentScale);
-
-                    var shadowH = shadow.Height > 0 ? shadow.Height : Height;
-                    var currentTY = LayerTranslationY(depth, shadow.Y, shadowH);
-                    var targetTY = LayerTranslationY(targetDepth, shadow.Y, shadowH);
-                    shadow.TranslationY = currentTY + progress * (targetTY - currentTY);
-                }
-            }
+            // Stack mode: back card and all shadows stay completely static during drag.
+            // Only the top card moves. This avoids the jarring "next photo coming out" effect.
         }
     }
 
@@ -1340,16 +1294,8 @@ public class SwipeCardView : ContentView, IDisposable
                     }
                     else
                     {
-                        // Stack mode: animate back card back to rest positions
-                        var stackScale = LayerScale(1);
-                        var stackY = ComputeStackTranslationY(prevCard, stackScale, StackOffset);
-                        var backScaleTask = prevCard.ScaleToAsync(stackScale, AnimationLength, Easing.SpringOut);
-                        var backTranslateTask = prevCard.TranslateToAsync(0, stackY, AnimationLength, Easing.SpringOut);
-
-                        await Task.WhenAll(translateTask, rotateTask, backScaleTask, backTranslateTask);
-
-                        // Reset shadow cards to rest positions
-                        PositionShadowCards();
+                        // Stack mode: back card and shadows didn't move, just snap top card back
+                        await Task.WhenAll(translateTask, rotateTask);
                     }
                 }
                 catch (Exception ex)
@@ -1364,13 +1310,10 @@ public class SwipeCardView : ContentView, IDisposable
                 // After the visible animation completes, reset the back card.
                 if (StackDepth > 0)
                 {
-                    // Stack mode: restore back card to rest state.
-                    var restScale = LayerScale(1);
-
-                    prevCard.Opacity = 1;
-                    prevCard.AnchorY = 0.5;
-                    prevCard.Scale = restScale;
-                    prevCard.TranslationY = ComputeStackTranslationY(prevCard, restScale, StackOffset);
+                    // Stack mode: back card stays hidden at home position.
+                    prevCard.Opacity = 0;
+                    prevCard.Scale = 1.0;
+                    InvalidateCardLayout(prevCard);
                 }
                 else
                 {
@@ -1462,12 +1405,10 @@ public class SwipeCardView : ContentView, IDisposable
 
             if (StackDepth > 0)
             {
-                // Stack mode: show back card at offset position
-                var stackScale = LayerScale(1);
+                // Stack mode: hide back card at home position.
+                // Shadow cards provide the visual strips behind the top card.
                 oldTopCard.AnchorY = 0.5;
-                oldTopCard.Opacity = 1;
-                oldTopCard.Scale = stackScale;
-                oldTopCard.TranslationY = ComputeStackTranslationY(oldTopCard, stackScale, StackOffset);
+                oldTopCard.Opacity = 0;
             }
             else
             {
@@ -1543,10 +1484,8 @@ public class SwipeCardView : ContentView, IDisposable
                 // Position the old top card as the back card
                 oldTopCard.BatchBegin();
                 oldTopCard.AnchorY = 0.5;
-                oldTopCard.Scale = StackDepth > 0 ? LayerScale(1) : 1.0;
-                oldTopCard.Opacity = StackDepth > 0 ? 1 : 0;
-                if (StackDepth > 0)
-                    oldTopCard.TranslationY = ComputeStackTranslationY(oldTopCard, LayerScale(1), StackOffset);
+                oldTopCard.Scale = 1.0;
+                oldTopCard.Opacity = 0;
                 oldTopCard.BatchCommit();
             }
             finally
@@ -1572,10 +1511,8 @@ public class SwipeCardView : ContentView, IDisposable
             // Position the old top card as the back card
             oldTopCard.BatchBegin();
             oldTopCard.AnchorY = 0.5;
-            oldTopCard.Scale = StackDepth > 0 ? LayerScale(1) : 1.0;
-            oldTopCard.Opacity = StackDepth > 0 ? 1 : 0;
-            if (StackDepth > 0)
-                oldTopCard.TranslationY = ComputeStackTranslationY(oldTopCard, LayerScale(1), StackOffset);
+            oldTopCard.Scale = 1.0;
+            oldTopCard.Opacity = 0;
             oldTopCard.BatchCommit();
         }
 

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -393,10 +393,8 @@ public class SwipeCardView : ContentView, IDisposable
                 Microsoft.Maui.Controls.ViewExtensions.CancelAnimations(card);
         }
 
-        foreach (var shadow in _shadowCards)
-        {
-            // Border doesn't implement IDisposable; removal from Children is sufficient.
-        }
+        // Shadow cards are removed from Children in RebuildShadowCards;
+        // just clear the list reference here.
         _shadowCards.Clear();
 
         SizeChanged -= OnSizeChangedForStack;
@@ -667,6 +665,10 @@ public class SwipeCardView : ContentView, IDisposable
                         card.IsVisible = false;
                     }
                 }
+                foreach (var shadow in _shadowCards)
+                {
+                    shadow.IsVisible = false;
+                }
 
                 _ignoreTouch = false;
                 TopItem = null;
@@ -708,6 +710,8 @@ public class SwipeCardView : ContentView, IDisposable
                     backCard.IsVisible = true;
                     _itemIndex++;
                 }
+                // Refresh shadow card visibility (handles transition from <2 to >=2 items)
+                PositionShadowCards();
                 break;
 
             case NotifyCollectionChangedAction.Remove:
@@ -831,7 +835,8 @@ public class SwipeCardView : ContentView, IDisposable
         if (newValue is int depth && depth <= 0)
         {
             // Stack mode disabled — restore non-stack back card state (hidden)
-            var backCard = swipeCardView._cards[swipeCardView.PrevCardIndex(swipeCardView._topCardIndex)];
+            var backIdx = swipeCardView.PrevCardIndex(swipeCardView._topCardIndex);
+            var backCard = swipeCardView._cards[backIdx];
             if (backCard != null)
             {
                 backCard.Opacity = 0;
@@ -859,26 +864,41 @@ public class SwipeCardView : ContentView, IDisposable
     private static void DisableNativeClipping(Grid grid)
     {
 #if ANDROID
+        // Apply immediately if the native handler is already available (runtime StackDepth change),
+        // otherwise subscribe to HandlerChanged to apply when the handler is first set.
+        if (grid.Handler?.PlatformView is Android.Views.ViewGroup existingNativeGrid)
+        {
+            ApplyClipSettings(existingNativeGrid);
+            return;
+        }
+
         EventHandler handler = null!;
         handler = (s, e) =>
         {
             if (grid.Handler?.PlatformView is Android.Views.ViewGroup nativeGrid)
             {
-                nativeGrid.SetClipChildren(false);
-                nativeGrid.SetClipToPadding(false);
-                var parent = nativeGrid.Parent;
-                for (int depth = 0; depth < 8 && parent is Android.Views.ViewGroup pg; depth++)
-                {
-                    pg.SetClipChildren(false);
-                    pg.SetClipToPadding(false);
-                    parent = pg.Parent;
-                }
+                ApplyClipSettings(nativeGrid);
             }
             grid.HandlerChanged -= handler;
         };
         grid.HandlerChanged += handler;
 #endif
     }
+
+#if ANDROID
+    private static void ApplyClipSettings(Android.Views.ViewGroup nativeGrid)
+    {
+        nativeGrid.SetClipChildren(false);
+        nativeGrid.SetClipToPadding(false);
+        var parent = nativeGrid.Parent;
+        for (int depth = 0; depth < 8 && parent is Android.Views.ViewGroup pg; depth++)
+        {
+            pg.SetClipChildren(false);
+            pg.SetClipToPadding(false);
+            parent = pg.Parent;
+        }
+    }
+#endif
 
     /// <summary>Creates or removes decorative Border elements for the stack visual effect.</summary>
     private void RebuildShadowCards()
@@ -894,7 +914,7 @@ public class SwipeCardView : ContentView, IDisposable
 
         if (StackDepth <= 0)
         {
-            grid.IsClippedToBounds = true;
+            // Non-stack mode: leave default (unclipped) so swipe-off animations aren't cut
             return;
         }
 
@@ -967,7 +987,8 @@ public class SwipeCardView : ContentView, IDisposable
         if (Content is not Grid grid) return;
         if (_shadowCards.Count == 0) return;
 
-        var hasItems = ItemsSource != null && ItemsSource.Count >= 2;
+        var hasItems = ItemsSource != null && ItemsSource.Count >= 2
+            && (LoopCards || ItemsSource.Count - _currentDisplayIndex >= 2);
 
         // Use the internal grid height (excludes SwipeCardView padding) for
         // more accurate compensation when element heights aren't available yet.

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -151,6 +151,14 @@ public class SwipeCardView : ContentView, IDisposable
             Core.StackDirection.Bottom,
             propertyChanged: OnStackVisualPropertyChanged);
 
+    public static readonly BindableProperty StackCardColorProperty =
+        BindableProperty.Create(
+            nameof(StackCardColor),
+            typeof(Color),
+            typeof(SwipeCardView),
+            null,
+            propertyChanged: OnStackCardColorPropertyChanged);
+
     #endregion Bindable Properties
 
     #region Constants
@@ -198,6 +206,7 @@ public class SwipeCardView : ContentView, IDisposable
     private int _collectionVersion = 0;
     private INotifyCollectionChanged? _subscribedCollection;
     private readonly List<Border> _shadowCards = new();
+    private Border? _backCardOverlay;
 
     #endregion Private fields
 
@@ -357,6 +366,13 @@ public class SwipeCardView : ContentView, IDisposable
         set => SetValue(StackDirectionProperty, value);
     }
 
+    /// <summary>Gets or sets the background color of decorative shadow cards in the stack. Default is White.</summary>
+    public Color? StackCardColor
+    {
+        get => (Color?)GetValue(StackCardColorProperty);
+        set => SetValue(StackCardColorProperty, value);
+    }
+
     #endregion Public Properties
 
     #region Public Methods
@@ -398,6 +414,12 @@ public class SwipeCardView : ContentView, IDisposable
             (shadow as IDisposable)?.Dispose();
         }
         _shadowCards.Clear();
+
+        if (_backCardOverlay != null)
+        {
+            (_backCardOverlay as IDisposable)?.Dispose();
+            _backCardOverlay = null;
+        }
 
         SizeChanged -= OnSizeChangedForStack;
 
@@ -553,6 +575,7 @@ public class SwipeCardView : ContentView, IDisposable
         swipeCardView.Content = null;
 
         var view = new Grid() { IsClippedToBounds = false };
+        DisableNativeClipping(view);
 
         // create a stack of cards
         for (var i = NumCards - 1; i >= 0; i--)
@@ -825,6 +848,103 @@ public class SwipeCardView : ContentView, IDisposable
         swipeCardView.PositionShadowCards();
     }
 
+    private static void OnStackCardColorPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        var swipeCardView = (SwipeCardView)bindable;
+
+        // Rebuild overlay when StackCardColor changes (null ↔ non-null affects overlay existence)
+        if ((oldValue == null) != (newValue == null))
+        {
+            swipeCardView.RebuildShadowCards();
+            swipeCardView.PositionShadowCards();
+        }
+        else
+        {
+            swipeCardView.ApplyGraduatedColors();
+        }
+    }
+
+    /// <summary>
+    /// Disables native clipping on a Grid so that shadow cards can extend beyond its bounds.
+    /// On Android, ViewGroup clips children by default; this explicitly disables it.
+    /// </summary>
+    private static void DisableNativeClipping(Grid grid)
+    {
+#if ANDROID
+        EventHandler handler = null!;
+        handler = (s, e) =>
+        {
+            if (grid.Handler?.PlatformView is Android.Views.ViewGroup nativeGrid)
+            {
+                nativeGrid.SetClipChildren(false);
+                nativeGrid.SetClipToPadding(false);
+                var parent = nativeGrid.Parent;
+                for (int depth = 0; depth < 8 && parent is Android.Views.ViewGroup pg; depth++)
+                {
+                    pg.SetClipChildren(false);
+                    pg.SetClipToPadding(false);
+                    parent = pg.Parent;
+                }
+            }
+            grid.HandlerChanged -= handler;
+        };
+        grid.HandlerChanged += handler;
+#endif
+    }
+
+    /// <summary>Blends a color toward white by the given factor (0 = unchanged, 1 = white).</summary>
+    private static Color GraduateColor(Color baseColor, double blendFactor)
+    {
+        blendFactor = Math.Clamp(blendFactor, 0, 1);
+        return new Color(
+            (float)(baseColor.Red + (1.0 - baseColor.Red) * blendFactor),
+            (float)(baseColor.Green + (1.0 - baseColor.Green) * blendFactor),
+            (float)(baseColor.Blue + (1.0 - baseColor.Blue) * blendFactor),
+            baseColor.Alpha);
+    }
+
+    /// <summary>Computes a thin stroke color slightly darker than the given fill.</summary>
+    private static Color StrokeColorFor(Color fillColor)
+    {
+        const double darkenFactor = 0.15;
+        return new Color(
+            (float)(fillColor.Red * (1 - darkenFactor)),
+            (float)(fillColor.Green * (1 - darkenFactor)),
+            (float)(fillColor.Blue * (1 - darkenFactor)),
+            fillColor.Alpha);
+    }
+
+    /// <summary>Applies graduated colors to overlay and shadow cards for visual depth.</summary>
+    private void ApplyGraduatedColors()
+    {
+        var baseColor = StackCardColor ?? Colors.White;
+        int totalLayers = StackDepth;
+        if (totalLayers < 1) totalLayers = 1;
+
+        // Layer 0 = overlay (closest to card, darkest).
+        // No stroke so the fill covers the back card edge-to-edge.
+        if (_backCardOverlay != null)
+        {
+            _backCardOverlay.BackgroundColor = baseColor;
+            _backCardOverlay.Stroke = null;
+            _backCardOverlay.StrokeThickness = 0;
+        }
+
+        // Shadow cards get progressively lighter so each strip is clearly
+        // distinguishable.  High maxBlend creates strong contrast between the
+        // closest strip (base color) and the farthest strip (almost white).
+        const double maxBlend = 0.95;
+        for (int i = 0; i < _shadowCards.Count; i++)
+        {
+            double t = (double)(i + 1) / totalLayers;
+            double blendFactor = t * maxBlend;
+            var layerColor = GraduateColor(baseColor, blendFactor);
+            _shadowCards[i].BackgroundColor = layerColor;
+            _shadowCards[i].Stroke = null;
+            _shadowCards[i].StrokeThickness = 0;
+        }
+    }
+
     /// <summary>Creates or removes decorative Border elements for the stack visual effect.</summary>
     private void RebuildShadowCards()
     {
@@ -838,81 +958,137 @@ public class SwipeCardView : ContentView, IDisposable
         }
         _shadowCards.Clear();
 
-        if (StackDepth <= 1) return;
-
-        // The back card provides level 1 of the stack. We create (StackDepth - 1)
-        // additional shadow cards for levels 2+.
-        int shadowCount = StackDepth - 1;
-        for (int i = 0; i < shadowCount; i++)
+        // Remove existing back card overlay
+        if (_backCardOverlay != null)
         {
-            var shadow = new Border
+            grid.Children.Remove(_backCardOverlay);
+            (_backCardOverlay as IDisposable)?.Dispose();
+            _backCardOverlay = null;
+        }
+
+        if (StackDepth <= 1 && StackCardColor == null) return;
+
+        var baseColor = StackCardColor ?? Colors.White;
+        int totalLayers = Math.Max(StackDepth, 1);
+
+        // Create shadow cards FIRST (deepest → shallowest) so they are earliest in Children
+        // and render behind everything at the same ZIndex.
+        if (StackDepth > 1)
+        {
+            int shadowCount = StackDepth - 1;
+            // Insert deepest shadow first (it renders furthest back)
+            for (int i = shadowCount - 1; i >= 0; i--)
             {
-                BackgroundColor = Colors.White,
-                Stroke = new SolidColorBrush(Color.FromArgb("#E0E0E0")),
-                StrokeThickness = 1,
-                StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle { CornerRadius = new CornerRadius(10) },
-                ZIndex = -1 - i,
+                double t = (double)(i + 1) / totalLayers;
+                double blendFactor = t * 0.95;
+                var layerColor = GraduateColor(baseColor, blendFactor);
+                var shadow = new Border
+                {
+                    BackgroundColor = layerColor,
+                    Stroke = null,
+                    StrokeThickness = 0,
+                    StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle { CornerRadius = new CornerRadius(12) },
+                    ZIndex = -(i + 1),
+                    InputTransparent = true,
+                    IsVisible = false,
+                    HorizontalOptions = LayoutOptions.Fill,
+                    VerticalOptions = LayoutOptions.Fill,
+                };
+                _shadowCards.Insert(0, shadow);
+                grid.Children.Insert(0, shadow);
+            }
+        }
+
+        // When StackCardColor is set, create an overlay that covers the back card.
+        // Inserted AFTER shadows but BEFORE cards in the children order.
+        if (StackCardColor != null && StackDepth > 0)
+        {
+            _backCardOverlay = new Border
+            {
+                BackgroundColor = baseColor,
+                Stroke = null,
+                StrokeThickness = 0,
+                StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle { CornerRadius = new CornerRadius(12) },
+                ZIndex = 0,
                 InputTransparent = true,
                 IsVisible = false,
-                AnchorY = 0.5,
-                Opacity = Math.Max(0.3, 1.0 - (0.2 * (i + 1)))
+                HorizontalOptions = LayoutOptions.Fill,
+                VerticalOptions = LayoutOptions.Fill,
             };
-            _shadowCards.Add(shadow);
-            grid.Children.Insert(0, shadow);
+            // Append AFTER the real cards so the overlay renders on top of the
+            // back card (later child at the same ZIndex wins) while the front card
+            // with ZIndex=1 still renders above everything.
+            grid.Children.Add(_backCardOverlay);
         }
+    }
+
+    /// <summary>Scale for a visible layer at the given depth (1 = back card/overlay, 2+ = shadows).</summary>
+    /// <remarks>
+    /// Uniform progression from 1.0 so every strip has equal side width.
+    /// Top card = 1.0, depth 1 = 1.0-step, depth 2 = 1.0-2*step, etc.
+    /// BackCardScale is NOT used here — in stack mode the back card scale
+    /// is driven by StackScaleStep for visual consistency.
+    /// </remarks>
+    private double LayerScale(int depth) => Math.Max(1.0 - depth * StackScaleStep, 0.5);
+
+    /// <summary>Cumulative offset for a given depth (linear: even spacing between strips).</summary>
+    /// <remarks>
+    /// Linear spacing so each strip peeks out by the same amount beyond the previous one,
+    /// matching the reference design where strips are evenly spaced.
+    /// Example with StackOffset=3: depth 1→3dp, depth 2→6dp, depth 3→9dp.
+    /// </remarks>
+    private double CumulativeOffset(int depth) => StackOffset * depth;
+
+    /// <summary>TranslationY for a decorative layer with scale compensation.</summary>
+    /// <remarks>
+    /// Center-anchored scaling retracts edges by H*(1-S)/2. We compensate so the
+    /// strip's outer edge aligns at the progressive cumulative offset from the card edge.
+    /// IMPORTANT: elementY and elementHeight must come from the element being
+    /// positioned (not from a different card), otherwise layout Y differences
+    /// cause misalignment.
+    /// </remarks>
+    private double LayerTranslationY(int depth, double elementY, double elementHeight)
+    {
+        var scale = LayerScale(depth);
+        var compensation = elementHeight * (1.0 - scale) / 2.0;
+        var dirSign = StackDirection == Core.StackDirection.Top ? -1.0 : 1.0;
+        return -elementY + dirSign * (CumulativeOffset(depth) + compensation);
     }
 
     /// <summary>Positions shadow cards at their rest state behind the real cards.</summary>
     private void PositionShadowCards()
     {
-        if (_shadowCards.Count == 0 || Content is not Grid) return;
+        if (Content is not Grid grid) return;
 
         var hasItems = ItemsSource != null && ItemsSource.Count > 0;
-        // Use back card height for compensation; fall back to container height
-        var refHeight = _cards[PrevCardIndex(_topCardIndex)]?.Height ?? Height;
-        if (refHeight <= 0) refHeight = Height;
 
-        var dirSign = StackDirection == Core.StackDirection.Top ? -1.0 : 1.0;
+        // Use the internal grid height (excludes SwipeCardView padding) for
+        // more accurate compensation when element heights aren't available yet.
+        var fallbackHeight = grid.Height > 0 ? grid.Height : Height;
+
+        // Position the back card overlay (depth 1) using its OWN layout position
+        if (_backCardOverlay != null)
+        {
+            var overlayH = _backCardOverlay.Height > 0 ? _backCardOverlay.Height : fallbackHeight;
+            _backCardOverlay.Scale = LayerScale(1);
+            _backCardOverlay.TranslationY = LayerTranslationY(1, _backCardOverlay.Y, overlayH);
+            _backCardOverlay.IsVisible = hasItems;
+        }
+
+        if (_shadowCards.Count == 0) return;
 
         for (int i = 0; i < _shadowCards.Count; i++)
         {
             var shadow = _shadowCards[i];
-            // Shadow i sits at depth (i + 2): back card is depth 1.
-            var scale = Math.Max(0.5, BackCardScale - ((i + 1) * StackScaleStep));
-            var compensation = refHeight * (1.0 - scale) / 2.0;
-            shadow.AnchorY = 0.5;
-            shadow.Scale = scale;
-            shadow.TranslationY = dirSign * ((i + 2) * StackOffset + compensation);
+            int depth = i + 2; // overlay is depth 1, shadows start at depth 2
+            var shadowH = shadow.Height > 0 ? shadow.Height : fallbackHeight;
+            shadow.Scale = LayerScale(depth);
+            shadow.TranslationY = LayerTranslationY(depth, shadow.Y, shadowH);
             shadow.IsVisible = hasItems;
         }
     }
 
-    /// <summary>Animates shadow cards during a swipe drag based on progress ratio (0..1).</summary>
-    private void AnimateShadowCards(float progressRatio)
-    {
-        if (_shadowCards.Count == 0) return;
-
-        progressRatio = Math.Min(Math.Max(progressRatio, 0f), 1f);
-
-        var refHeight = _cards[PrevCardIndex(_topCardIndex)]?.Height ?? Height;
-        if (refHeight <= 0) refHeight = Height;
-
-        var dirSign = StackDirection == Core.StackDirection.Top ? -1.0 : 1.0;
-
-        for (int i = 0; i < _shadowCards.Count; i++)
-        {
-            // Shadow i animates from depth (i+2) toward depth (i+1).
-            var restScale = Math.Max(0.5, BackCardScale - ((i + 1) * StackScaleStep));
-            var targetScale = Math.Max(0.5, restScale + (progressRatio * StackScaleStep));
-            var compensation = refHeight * (1.0 - targetScale) / 2.0;
-            var restTY = (i + 2) * StackOffset;
-            var targetTY = restTY - (progressRatio * StackOffset);
-
-            _shadowCards[i].Scale = targetScale;
-            _shadowCards[i].TranslationY = dirSign * (targetTY + compensation);
-        }
-    }
-
+    /// <summary>Hides shadow cards and overlay during a swipe drag for a clean transition.</summary>
     /// <summary>Resets shadow cards to rest position after a swipe or snap-back.</summary>
     private void ResetShadowCards()
     {
@@ -1036,12 +1212,26 @@ public class SwipeCardView : ContentView, IDisposable
         }
 
         // Center-anchored scaling with compensated TranslationY:
-        // The card is scaled from its center (AnchorY=0.5), then pushed down enough
-        // that its bottom edge peeks exactly StackOffset dp below the top card.
+        // The card is scaled from its center (AnchorY=0.5), then pushed enough
+        // that its edge peeks exactly StackOffset dp beyond the top card.
+        var stackScale = LayerScale(1);
         backCard.AnchorY = 0.5;
-        backCard.Scale = BackCardScale;
+        backCard.Scale = stackScale;
         backCard.Opacity = 1;
-        backCard.TranslationY = ComputeStackTranslationY(backCard, BackCardScale, StackOffset);
+        backCard.TranslationY = ComputeStackTranslationY(backCard, stackScale, StackOffset);
+
+        // Position overlay to exactly match the back card so it covers it fully.
+        if (_backCardOverlay != null)
+        {
+            _backCardOverlay.Scale = stackScale;
+            _backCardOverlay.TranslationY = backCard.TranslationY;
+            _backCardOverlay.IsVisible = true;
+        }
+
+        // Reposition shadow cards now that layout has computed correct heights.
+        // The initial PositionShadowCards() in Setup() may have used incorrect
+        // height fallbacks before elements were laid out.
+        PositionShadowCards();
     }
 
     private void OnSizeChangedForStack(object? sender, EventArgs e)
@@ -1068,18 +1258,17 @@ public class SwipeCardView : ContentView, IDisposable
             return;
         }
 
-        // Reveal the back card for the parallax scale effect during drag.
-        // Apply BackCardScale now (not during layout) so the native platform
-        // always computes full-size bounds for the card.
-        var backCard = _cards[PrevCardIndex(_topCardIndex)];
-        if (backCard != null)
+        // In stack mode the back card and all decorative strips stay completely
+        // static during the drag — only the top card moves.  The overlay covers
+        // the back card so nothing behind it is visible to the user.
+        if (StackDepth <= 0)
         {
-            backCard.Scale = BackCardScale;
-            backCard.Opacity = 1;
-            // When stack is active, move back card from offset position to top
-            if (StackDepth > 0)
+            // Normal mode: reveal the back card for the parallax scale effect.
+            var backCard = _cards[PrevCardIndex(_topCardIndex)];
+            if (backCard != null)
             {
-                backCard.TranslationY = -backCard.Y;
+                backCard.Scale = BackCardScale;
+                backCard.Opacity = 1;
             }
         }
 
@@ -1147,27 +1336,57 @@ public class SwipeCardView : ContentView, IDisposable
             }
         }
 
-        // Scale the back card (guard against Threshold==0)
+        // Scale the back card (guard against Threshold==0).
         if (backCard != null && backCard.IsVisible && Threshold > 0)
         {
             var cardDistance = Math.Abs(differenceX) > Math.Abs(differenceY) ? differenceX : differenceY;
-            var newScale = Math.Min(BackCardScale + Math.Abs((cardDistance / Threshold) * (1.0f - BackCardScale)), 1.0f);
-            backCard.Scale = newScale;
 
-            // When stack is active, update TranslationY to track the changing scale
-            // (compensation depends on scale, so it must update each frame)
-            if (StackDepth > 0)
+            if (StackDepth <= 0)
             {
-                var progressRatio = (float)Math.Min(Math.Abs(cardDistance) / Threshold, 1.0);
-                var targetPeek = StackOffset * (1.0 - progressRatio); // peek shrinks as card grows
-                backCard.TranslationY = ComputeStackTranslationY(backCard, newScale, targetPeek);
+                // Normal mode: parallax scale from BackCardScale → 1.0
+                var newScale = Math.Min(BackCardScale + Math.Abs((cardDistance / Threshold) * (1.0f - BackCardScale)), 1.0f);
+                backCard.Scale = newScale;
             }
-
-            // Animate shadow cards in sync with the back card scale
-            if (_shadowCards.Count > 0)
+            else
             {
-                var progressRatio = (float)Math.Min(Math.Abs(cardDistance) / Threshold, 1.0);
-                AnimateShadowCards(progressRatio);
+                // Stack mode: progressively reveal back card photo as top card drags away.
+                // The overlay fades out and the back card scales/translates toward its
+                // "new top card" position, creating a smooth transition.
+                var distance = Math.Max(Math.Abs(differenceX), Math.Abs(differenceY));
+                var progress = Math.Clamp(distance / Threshold, 0, 1);
+                var stackScale = LayerScale(1);
+
+                // Scale back card from stack scale toward 1.0
+                backCard.Scale = stackScale + progress * (1.0 - stackScale);
+
+                // Translate back card from stack offset toward home position
+                var homeY = -backCard.Y;
+                var stackY = ComputeStackTranslationY(backCard, stackScale, StackOffset);
+                backCard.TranslationY = stackY + progress * (homeY - stackY);
+
+                // Overlay tracks back card exactly (fading as it goes)
+                if (_backCardOverlay != null)
+                {
+                    _backCardOverlay.Opacity = 1.0 - progress;
+                    _backCardOverlay.Scale = backCard.Scale;
+                    _backCardOverlay.TranslationY = backCard.TranslationY;
+                }
+
+                // Advance shadow cards one level closer
+                for (int i = 0; i < _shadowCards.Count; i++)
+                {
+                    var shadow = _shadowCards[i];
+                    int depth = i + 2;
+                    int targetDepth = depth - 1;
+                    var currentScale = LayerScale(depth);
+                    var targetScale = LayerScale(targetDepth);
+                    shadow.Scale = currentScale + progress * (targetScale - currentScale);
+
+                    var shadowH = shadow.Height > 0 ? shadow.Height : Height;
+                    var currentTY = LayerTranslationY(depth, shadow.Y, shadowH);
+                    var targetTY = LayerTranslationY(targetDepth, shadow.Y, shadowH);
+                    shadow.TranslationY = currentTY + progress * (targetTY - currentTY);
+                }
             }
         }
     }
@@ -1233,8 +1452,16 @@ public class SwipeCardView : ContentView, IDisposable
                 var backCard = _cards[NextCardIndex(_topCardIndex)];
                 backCard.CancelAnimations();
                 backCard.Scale = 1.0;
+                backCard.TranslationY = -backCard.Y;
                 backCard.AnchorY = 0.5;
                 InvalidateCardLayout(backCard);
+
+                // Hide overlay before the back card transitions to new top card
+                if (_backCardOverlay != null)
+                {
+                    _backCardOverlay.IsVisible = false;
+                    _backCardOverlay.Opacity = 1.0; // reset for next card
+                }
 
                 // State transition must happen regardless of animation success
                 topCard.IsVisible = false;
@@ -1267,10 +1494,36 @@ public class SwipeCardView : ContentView, IDisposable
                     // Animate top card back to home position
                     var translateTask = topCard.TranslateToAsync(0, -topCard.Y, AnimationLength, Easing.SpringOut);
                     var rotateTask = topCard.RotateToAsync(0, AnimationLength, Easing.SpringOut);
-                    // Animate back card scale down (the nice parallax shrink effect)
-                    var scaleTask = prevCard.ScaleToAsync(BackCardScale, AnimationLength, Easing.SpringOut);
 
-                    await Task.WhenAll(translateTask, rotateTask, scaleTask);
+                    if (StackDepth <= 0)
+                    {
+                        // Normal mode: animate back card scale down (parallax shrink)
+                        var scaleTask = prevCard.ScaleToAsync(BackCardScale, AnimationLength, Easing.SpringOut);
+                        await Task.WhenAll(translateTask, rotateTask, scaleTask);
+                    }
+                    else
+                    {
+                        // Stack mode: animate back card + overlay back to rest positions
+                        var stackScale = LayerScale(1);
+                        var stackY = ComputeStackTranslationY(prevCard, stackScale, StackOffset);
+                        var backScaleTask = prevCard.ScaleToAsync(stackScale, AnimationLength, Easing.SpringOut);
+                        var backTranslateTask = prevCard.TranslateToAsync(0, stackY, AnimationLength, Easing.SpringOut);
+
+                        if (_backCardOverlay != null)
+                        {
+                            var overlayFadeTask = _backCardOverlay.FadeToAsync(1.0, AnimationLength);
+                            var overlayScaleTask = _backCardOverlay.ScaleToAsync(stackScale, AnimationLength, Easing.SpringOut);
+                            var overlayTranslateTask = _backCardOverlay.TranslateToAsync(0, stackY, AnimationLength, Easing.SpringOut);
+                            await Task.WhenAll(translateTask, rotateTask, backScaleTask, backTranslateTask, overlayFadeTask, overlayScaleTask, overlayTranslateTask);
+                        }
+                        else
+                        {
+                            await Task.WhenAll(translateTask, rotateTask, backScaleTask, backTranslateTask);
+                        }
+
+                        // Reset shadow cards to rest positions
+                        PositionShadowCards();
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -1284,12 +1537,20 @@ public class SwipeCardView : ContentView, IDisposable
                 // After the visible animation completes, reset the back card.
                 if (StackDepth > 0)
                 {
-                    // Stack mode: keep back card visible at offset position
+                    // Stack mode: restore back card and overlay to rest state.
+                    var restScale = LayerScale(1);
+                    if (_backCardOverlay != null)
+                    {
+                        _backCardOverlay.Opacity = 1.0;
+                        _backCardOverlay.Scale = restScale;
+                    }
+
                     prevCard.Opacity = 1;
                     prevCard.AnchorY = 0.5;
-                    prevCard.Scale = BackCardScale;
-                    prevCard.TranslationY = ComputeStackTranslationY(prevCard, BackCardScale, StackOffset);
-                    ResetShadowCards();
+                    prevCard.Scale = restScale;
+                    prevCard.TranslationY = ComputeStackTranslationY(prevCard, restScale, StackOffset);
+                    if (_backCardOverlay != null)
+                        _backCardOverlay.TranslationY = prevCard.TranslationY;
                 }
                 else
                 {
@@ -1382,10 +1643,20 @@ public class SwipeCardView : ContentView, IDisposable
             if (StackDepth > 0)
             {
                 // Stack mode: show back card at offset position
+                var stackScale = LayerScale(1);
                 oldTopCard.AnchorY = 0.5;
                 oldTopCard.Opacity = 1;
-                oldTopCard.Scale = BackCardScale;
-                oldTopCard.TranslationY = ComputeStackTranslationY(oldTopCard, BackCardScale, StackOffset);
+                oldTopCard.Scale = stackScale;
+                oldTopCard.TranslationY = ComputeStackTranslationY(oldTopCard, stackScale, StackOffset);
+
+                // Position overlay to match back card exactly
+                if (_backCardOverlay != null)
+                {
+                    _backCardOverlay.Scale = stackScale;
+                    _backCardOverlay.TranslationY = oldTopCard.TranslationY;
+                    _backCardOverlay.IsVisible = true;
+                    _backCardOverlay.Opacity = 1.0;
+                }
             }
             else
             {
@@ -1461,10 +1732,10 @@ public class SwipeCardView : ContentView, IDisposable
                 // Position the old top card as the back card
                 oldTopCard.BatchBegin();
                 oldTopCard.AnchorY = 0.5;
-                oldTopCard.Scale = StackDepth > 0 ? (double)BackCardScale : 1.0;
+                oldTopCard.Scale = StackDepth > 0 ? LayerScale(1) : 1.0;
                 oldTopCard.Opacity = StackDepth > 0 ? 1 : 0;
                 if (StackDepth > 0)
-                    oldTopCard.TranslationY = ComputeStackTranslationY(oldTopCard, BackCardScale, StackOffset);
+                    oldTopCard.TranslationY = ComputeStackTranslationY(oldTopCard, LayerScale(1), StackOffset);
                 oldTopCard.BatchCommit();
             }
             finally
@@ -1490,10 +1761,10 @@ public class SwipeCardView : ContentView, IDisposable
             // Position the old top card as the back card
             oldTopCard.BatchBegin();
             oldTopCard.AnchorY = 0.5;
-            oldTopCard.Scale = StackDepth > 0 ? (double)BackCardScale : 1.0;
+            oldTopCard.Scale = StackDepth > 0 ? LayerScale(1) : 1.0;
             oldTopCard.Opacity = StackDepth > 0 ? 1 : 0;
             if (StackDepth > 0)
-                oldTopCard.TranslationY = ComputeStackTranslationY(oldTopCard, BackCardScale, StackOffset);
+                oldTopCard.TranslationY = ComputeStackTranslationY(oldTopCard, LayerScale(1), StackOffset);
             oldTopCard.BatchCommit();
         }
 
@@ -1508,6 +1779,16 @@ public class SwipeCardView : ContentView, IDisposable
         PreviousItem = _currentDisplayIndex >= 1 ? ItemsSource[_currentDisplayIndex - 1] : null;
 
         ResetShadowCards();
+
+        // Position overlay to match the new back card
+        if (_backCardOverlay != null && StackDepth > 0)
+        {
+            var stackScale = LayerScale(1);
+            _backCardOverlay.Scale = stackScale;
+            _backCardOverlay.TranslationY = oldTopCard.TranslationY;
+            _backCardOverlay.Opacity = 1.0;
+            _backCardOverlay.IsVisible = true;
+        }
 
         // Force layout recalculation
         try

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -987,8 +987,23 @@ public class SwipeCardView : ContentView, IDisposable
         if (Content is not Grid grid) return;
         if (_shadowCards.Count == 0) return;
 
-        var hasItems = ItemsSource != null && ItemsSource.Count >= 2
-            && (LoopCards || ItemsSource.Count - _currentDisplayIndex >= 2);
+        // Calculate how many shadow strips should be visible based on remaining cards.
+        // Each shadow suggests a card behind; don't show more shadows than actual remaining cards.
+        // remainingCards includes the top card, so subtract 1 for the "depth behind" count.
+        int visibleShadows = 0;
+        if (ItemsSource != null && ItemsSource.Count >= 2)
+        {
+            if (LoopCards)
+            {
+                visibleShadows = _shadowCards.Count;
+            }
+            else
+            {
+                var remaining = ItemsSource.Count - _currentDisplayIndex;
+                // remaining-1 = cards behind top card; cap at shadow count
+                visibleShadows = Math.Min(Math.Max(remaining - 1, 0), _shadowCards.Count);
+            }
+        }
 
         // Use the internal grid height (excludes SwipeCardView padding) for
         // more accurate compensation when element heights aren't available yet.
@@ -1001,7 +1016,7 @@ public class SwipeCardView : ContentView, IDisposable
             var shadowH = shadow.Height > 0 ? shadow.Height : fallbackHeight;
             shadow.Scale = LayerScale(depth);
             shadow.TranslationY = LayerTranslationY(depth, shadow.Y, shadowH);
-            shadow.IsVisible = hasItems;
+            shadow.IsVisible = i < visibleShadows;
         }
     }
 

--- a/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
+++ b/src/Plugin.Maui.SwipeCardView/SwipeCardView.cs
@@ -115,6 +115,31 @@ public class SwipeCardView : ContentView, IDisposable
             typeof(SwipeCardView),
             DefaultLoopCards);
 
+    public static readonly BindableProperty StackDepthProperty =
+        BindableProperty.Create(
+            nameof(StackDepth),
+            typeof(int),
+            typeof(SwipeCardView),
+            0,
+            validateValue: (_, value) => value is int i && i >= 0 && i <= 3,
+            propertyChanged: OnStackDepthPropertyChanged);
+
+    public static readonly BindableProperty StackOffsetProperty =
+        BindableProperty.Create(
+            nameof(StackOffset),
+            typeof(double),
+            typeof(SwipeCardView),
+            10.0,
+            validateValue: (_, value) => value is double d && d >= 0);
+
+    public static readonly BindableProperty StackScaleStepProperty =
+        BindableProperty.Create(
+            nameof(StackScaleStep),
+            typeof(double),
+            typeof(SwipeCardView),
+            0.03,
+            validateValue: (_, value) => value is double d && d >= 0 && d <= 0.5);
+
     #endregion Bindable Properties
 
     #region Constants
@@ -161,12 +186,15 @@ public class SwipeCardView : ContentView, IDisposable
     private bool _programmaticSwipe = false;
     private int _collectionVersion = 0;
     private INotifyCollectionChanged? _subscribedCollection;
+    private readonly List<Border> _shadowCards = new();
 
     #endregion Private fields
 
     public SwipeCardView()
     {
-        var view = new Grid();
+        IsClippedToBounds = false;
+
+        var view = new Grid { IsClippedToBounds = false };
 
         Content = view;
 
@@ -260,7 +288,9 @@ public class SwipeCardView : ContentView, IDisposable
         set => SetValue(SupportedDraggingDirectionsProperty, value);
     }
 
-    /// <summary>Gets or sets the initial scale of the back card (0.0–1.0). Scales up to 1.0 as the top card is dragged. Default is 0.8.</summary>
+    /// <summary>Gets or sets the initial scale of the back card (0.0–1.0). Scales up to 1.0 as the top card is dragged.
+    /// When <see cref="StackDepth"/> &gt; 1, this is the scale of the first back card; successive shadow cards
+    /// scale down further by <see cref="StackScaleStep"/> each. Default is 0.8.</summary>
     public float BackCardScale
     {
         get => (float)GetValue(BackCardScaleProperty);
@@ -286,6 +316,27 @@ public class SwipeCardView : ContentView, IDisposable
     {
         get => (bool)GetValue(LoopCardsProperty);
         set => SetValue(LoopCardsProperty, value);
+    }
+
+    /// <summary>Gets or sets the number of decorative cards visible behind the top card to create a stack effect (0–3). Default is 0 (no stack).</summary>
+    public int StackDepth
+    {
+        get => (int)GetValue(StackDepthProperty);
+        set => SetValue(StackDepthProperty, value);
+    }
+
+    /// <summary>Gets or sets the vertical offset (in device-independent units) between each stacked card. Default is 10.</summary>
+    public double StackOffset
+    {
+        get => (double)GetValue(StackOffsetProperty);
+        set => SetValue(StackOffsetProperty, value);
+    }
+
+    /// <summary>Gets or sets the scale reduction applied to each successive card in the stack. Default is 0.03 (each card is 3% smaller).</summary>
+    public double StackScaleStep
+    {
+        get => (double)GetValue(StackScaleStepProperty);
+        set => SetValue(StackScaleStepProperty, value);
     }
 
     #endregion Public Properties
@@ -323,6 +374,14 @@ public class SwipeCardView : ContentView, IDisposable
             if (card != null)
                 Microsoft.Maui.Controls.ViewExtensions.CancelAnimations(card);
         }
+
+        foreach (var shadow in _shadowCards)
+        {
+            (shadow as IDisposable)?.Dispose();
+        }
+        _shadowCards.Clear();
+
+        SizeChanged -= OnSizeChangedForStack;
 
         var panGesture = GestureRecognizers.OfType<PanGestureRecognizer>().FirstOrDefault();
         if (panGesture != null)
@@ -475,7 +534,7 @@ public class SwipeCardView : ContentView, IDisposable
 
         swipeCardView.Content = null;
 
-        var view = new Grid();
+        var view = new Grid() { IsClippedToBounds = false };
 
         // create a stack of cards
         for (var i = NumCards - 1; i >= 0; i--)
@@ -498,6 +557,7 @@ public class SwipeCardView : ContentView, IDisposable
         }
 
         swipeCardView.Content = view;
+        swipeCardView.RebuildShadowCards();
 
         // If ItemsSource was already set before the template, initialize the cards now
         if (swipeCardView.ItemsSource != null && swipeCardView.ItemsSource.Count > 0)
@@ -732,6 +792,103 @@ public class SwipeCardView : ContentView, IDisposable
 
     #region Private Methods
 
+    private static void OnStackDepthPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        var swipeCardView = (SwipeCardView)bindable;
+        swipeCardView.RebuildShadowCards();
+        swipeCardView.PositionShadowCards();
+    }
+
+    /// <summary>Creates or removes decorative Border elements for the stack visual effect.</summary>
+    private void RebuildShadowCards()
+    {
+        if (Content is not Grid grid) return;
+
+        // Remove existing shadow cards
+        foreach (var shadow in _shadowCards)
+        {
+            grid.Children.Remove(shadow);
+            (shadow as IDisposable)?.Dispose();
+        }
+        _shadowCards.Clear();
+
+        if (StackDepth <= 1) return;
+
+        // The back card provides level 1 of the stack. We create (StackDepth - 1)
+        // additional shadow cards for levels 2+.
+        int shadowCount = StackDepth - 1;
+        for (int i = 0; i < shadowCount; i++)
+        {
+            var shadow = new Border
+            {
+                BackgroundColor = Colors.White,
+                Stroke = new SolidColorBrush(Color.FromArgb("#E0E0E0")),
+                StrokeThickness = 1,
+                StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle { CornerRadius = new CornerRadius(10) },
+                ZIndex = -1 - i,
+                InputTransparent = true,
+                IsVisible = false,
+                AnchorY = 0.5,
+                Opacity = Math.Max(0.3, 1.0 - (0.2 * (i + 1)))
+            };
+            _shadowCards.Add(shadow);
+            grid.Children.Insert(0, shadow);
+        }
+    }
+
+    /// <summary>Positions shadow cards at their rest state behind the real cards.</summary>
+    private void PositionShadowCards()
+    {
+        if (_shadowCards.Count == 0 || Content is not Grid) return;
+
+        var hasItems = ItemsSource != null && ItemsSource.Count > 0;
+        // Use back card height for compensation; fall back to container height
+        var refHeight = _cards[PrevCardIndex(_topCardIndex)]?.Height ?? Height;
+        if (refHeight <= 0) refHeight = Height;
+
+        for (int i = 0; i < _shadowCards.Count; i++)
+        {
+            var shadow = _shadowCards[i];
+            // Shadow i sits at depth (i + 2): back card is depth 1.
+            var scale = Math.Max(0.5, BackCardScale - ((i + 1) * StackScaleStep));
+            var compensation = refHeight * (1.0 - scale) / 2.0;
+            shadow.AnchorY = 0.5;
+            shadow.Scale = scale;
+            shadow.TranslationY = (i + 2) * StackOffset + compensation;
+            shadow.IsVisible = hasItems;
+        }
+    }
+
+    /// <summary>Animates shadow cards during a swipe drag based on progress ratio (0..1).</summary>
+    private void AnimateShadowCards(float progressRatio)
+    {
+        if (_shadowCards.Count == 0) return;
+
+        progressRatio = Math.Min(Math.Max(progressRatio, 0f), 1f);
+
+        var refHeight = _cards[PrevCardIndex(_topCardIndex)]?.Height ?? Height;
+        if (refHeight <= 0) refHeight = Height;
+
+        for (int i = 0; i < _shadowCards.Count; i++)
+        {
+            // Shadow i animates from depth (i+2) toward depth (i+1).
+            var restScale = Math.Max(0.5, BackCardScale - ((i + 1) * StackScaleStep));
+            var targetScale = Math.Max(0.5, restScale + (progressRatio * StackScaleStep));
+            var compensation = refHeight * (1.0 - targetScale) / 2.0;
+            var restTY = (i + 2) * StackOffset;
+            var targetTY = restTY - (progressRatio * StackOffset);
+
+            _shadowCards[i].Scale = targetScale;
+            _shadowCards[i].TranslationY = targetTY + compensation;
+        }
+    }
+
+    /// <summary>Resets shadow cards to rest position after a swipe or snap-back.</summary>
+    private void ResetShadowCards()
+    {
+        PositionShadowCards();
+    }
+
     private void Setup()
     {
         if (ItemsSource == null)
@@ -775,6 +932,7 @@ public class SwipeCardView : ContentView, IDisposable
             // full-size bounds. The BackCardScale is applied only as a temporary
             // visual transform when dragging starts (see HandleTouchStart).
             card.Scale = 1.0;
+            card.AnchorY = 0.5;
             card.Rotation = 0;
             card.TranslationX = 0;
             card.TranslationY = -card.Y;
@@ -787,6 +945,75 @@ public class SwipeCardView : ContentView, IDisposable
             _itemIndex++;
         }
         Content.IsVisible = wasVisible;
+
+        // When stack effect is enabled, show the back card and shadow cards
+        // after layout has computed bounds at Scale=1.0.
+        if (StackDepth > 0)
+        {
+            try
+            {
+                Dispatcher.Dispatch(() => ApplyStackVisuals());
+            }
+            catch (InvalidOperationException)
+            {
+                // No dispatcher (unit test context) — apply synchronously
+                ApplyStackVisuals();
+            }
+        }
+
+        PositionShadowCards();
+    }
+
+    /// <summary>Computes the TranslationY needed for a back card to peek by the desired offset.</summary>
+    /// <remarks>
+    /// With center-anchored scaling (AnchorY=0.5), a scaled card's bottom edge retracts by
+    /// H*(1-Scale)/2. To produce a visible peek of <paramref name="peekAmount"/> dp,
+    /// the total TranslationY must compensate for this retraction.
+    /// </remarks>
+    private double ComputeStackTranslationY(View card, double scale, double peekAmount)
+    {
+        var height = card.Height;
+        if (height <= 0) height = Height; // fallback to container height
+        var compensation = height * (1.0 - scale) / 2.0;
+        return -card.Y + peekAmount + compensation;
+    }
+
+    /// <summary>Applies visual transforms for the stack effect (called after layout pass).</summary>
+    private void ApplyStackVisuals()
+    {
+        if (StackDepth <= 0 || ItemsSource == null || ItemsSource.Count < 2) return;
+
+        var backCard = _cards[PrevCardIndex(_topCardIndex)];
+        if (backCard == null || !backCard.IsVisible) return;
+
+        // We need the card height (or container height) for compensation.
+        // If neither is available yet (first layout pass), subscribe to SizeChanged.
+        var refHeight = backCard.Height > 0 ? backCard.Height : Height;
+        if (refHeight <= 0)
+        {
+            // Heights not ready — defer until layout completes
+            SizeChanged -= OnSizeChangedForStack;
+            SizeChanged += OnSizeChangedForStack;
+            return;
+        }
+
+        // Center-anchored scaling with compensated TranslationY:
+        // The card is scaled from its center (AnchorY=0.5), then pushed down enough
+        // that its bottom edge peeks exactly StackOffset dp below the top card.
+        backCard.AnchorY = 0.5;
+        backCard.Scale = BackCardScale;
+        backCard.Opacity = 1;
+        backCard.TranslationY = ComputeStackTranslationY(backCard, BackCardScale, StackOffset);
+    }
+
+    private void OnSizeChangedForStack(object? sender, EventArgs e)
+    {
+        if (Height > 0)
+        {
+            SizeChanged -= OnSizeChangedForStack;
+            ApplyStackVisuals();
+            PositionShadowCards();
+        }
     }
 
     // Handle when a touch event begins
@@ -811,6 +1038,11 @@ public class SwipeCardView : ContentView, IDisposable
         {
             backCard.Scale = BackCardScale;
             backCard.Opacity = 1;
+            // When stack is active, move back card from offset position to top
+            if (StackDepth > 0)
+            {
+                backCard.TranslationY = -backCard.Y;
+            }
         }
 
         _cardDistanceX = 0;
@@ -881,7 +1113,24 @@ public class SwipeCardView : ContentView, IDisposable
         if (backCard != null && backCard.IsVisible && Threshold > 0)
         {
             var cardDistance = Math.Abs(differenceX) > Math.Abs(differenceY) ? differenceX : differenceY;
-            backCard.Scale = Math.Min(BackCardScale + Math.Abs((cardDistance / Threshold) * (1.0f - BackCardScale)), 1.0f);
+            var newScale = Math.Min(BackCardScale + Math.Abs((cardDistance / Threshold) * (1.0f - BackCardScale)), 1.0f);
+            backCard.Scale = newScale;
+
+            // When stack is active, update TranslationY to track the changing scale
+            // (compensation depends on scale, so it must update each frame)
+            if (StackDepth > 0)
+            {
+                var progressRatio = (float)Math.Min(Math.Abs(cardDistance) / Threshold, 1.0);
+                var targetPeek = StackOffset * (1.0 - progressRatio); // peek shrinks as card grows
+                backCard.TranslationY = ComputeStackTranslationY(backCard, newScale, targetPeek);
+            }
+
+            // Animate shadow cards in sync with the back card scale
+            if (_shadowCards.Count > 0)
+            {
+                var progressRatio = (float)Math.Min(Math.Abs(cardDistance) / Threshold, 1.0);
+                AnimateShadowCards(progressRatio);
+            }
         }
     }
 
@@ -946,6 +1195,7 @@ public class SwipeCardView : ContentView, IDisposable
                 var backCard = _cards[NextCardIndex(_topCardIndex)];
                 backCard.CancelAnimations();
                 backCard.Scale = 1.0;
+                backCard.AnchorY = 0.5;
                 InvalidateCardLayout(backCard);
 
                 // State transition must happen regardless of animation success
@@ -993,14 +1243,24 @@ public class SwipeCardView : ContentView, IDisposable
                 topCard.Scale = 1.0;
                 topCard.TranslationX = 0;
 
-                // After the visible animation completes, reset the back card to
-                // Scale=1.0 and hide it. This prevents Android's native layout
-                // system from caching bounds at the smaller BackCardScale, which
-                // would cause the card to render at 80% size when it next becomes
-                // the top card.
-                prevCard.Opacity = 0;
-                prevCard.Scale = 1.0;
-                InvalidateCardLayout(prevCard);
+                // After the visible animation completes, reset the back card.
+                if (StackDepth > 0)
+                {
+                    // Stack mode: keep back card visible at offset position
+                    prevCard.Opacity = 1;
+                    prevCard.AnchorY = 0.5;
+                    prevCard.Scale = BackCardScale;
+                    prevCard.TranslationY = ComputeStackTranslationY(prevCard, BackCardScale, StackOffset);
+                    ResetShadowCards();
+                }
+                else
+                {
+                    // Normal mode: hide the back card and reset scale to 1.0
+                    // to prevent Android layout cache issues.
+                    prevCard.Opacity = 0;
+                    prevCard.Scale = 1.0;
+                    InvalidateCardLayout(prevCard);
+                }
             }
         }
         catch (Exception ex)
@@ -1045,7 +1305,9 @@ public class SwipeCardView : ContentView, IDisposable
         newTopCard.BatchBegin();
         newTopCard.ZIndex = 1;
         newTopCard.Scale = 1.0;
+        newTopCard.AnchorY = 0.5;
         newTopCard.TranslationX = 0;
+        newTopCard.TranslationY = -newTopCard.Y;
         newTopCard.Opacity = 1;
         newTopCard.BatchCommit();
 
@@ -1055,12 +1317,12 @@ public class SwipeCardView : ContentView, IDisposable
 
         // If there are more cards to show, recycle the old top card
         // for the next item in the source
-        if (_itemIndex >= ItemsSource.Count && LoopCards)
+        if (ItemsSource is not null && _itemIndex >= ItemsSource.Count && LoopCards)
         {
             _itemIndex = 0;
         }
 
-        if (_itemIndex < ItemsSource.Count)
+        if (ItemsSource is not null && _itemIndex < ItemsSource.Count)
         {
             // Cancel any lingering animations before recycling
             if (oldTopCard == null) return;
@@ -1078,10 +1340,25 @@ public class SwipeCardView : ContentView, IDisposable
 
             oldTopCard.BindingContext = ItemsSource[_itemIndex];
             oldTopCard.IsVisible = true;
-            // Hide recycled back card to prevent rendering bleed-through
-            oldTopCard.Opacity = 0;
+
+            if (StackDepth > 0)
+            {
+                // Stack mode: show back card at offset position
+                oldTopCard.AnchorY = 0.5;
+                oldTopCard.Opacity = 1;
+                oldTopCard.Scale = BackCardScale;
+                oldTopCard.TranslationY = ComputeStackTranslationY(oldTopCard, BackCardScale, StackOffset);
+            }
+            else
+            {
+                // Normal mode: hide recycled back card to prevent rendering bleed-through
+                oldTopCard.AnchorY = 0.5;
+                oldTopCard.Opacity = 0;
+            }
             _itemIndex++;
         }
+
+        ResetShadowCards();
     }
 
     private async void ShowPreviousCard(bool animated = false)
@@ -1122,6 +1399,7 @@ public class SwipeCardView : ContentView, IDisposable
                 newTopCard.BatchBegin();
                 newTopCard.BindingContext = previousItem;
                 newTopCard.Scale = 1.0;
+                newTopCard.AnchorY = 0.5;
                 newTopCard.Rotation = 0;
                 newTopCard.TranslationX = -Width;
                 newTopCard.TranslationY = -newTopCard.Y;
@@ -1142,10 +1420,13 @@ public class SwipeCardView : ContentView, IDisposable
                     newTopCard.TranslationX = 0;
                 }
 
-                // Hide the old top card now that animation is complete
+                // Position the old top card as the back card
                 oldTopCard.BatchBegin();
-                oldTopCard.Scale = 1.0;
-                oldTopCard.Opacity = 0;
+                oldTopCard.AnchorY = 0.5;
+                oldTopCard.Scale = StackDepth > 0 ? (double)BackCardScale : 1.0;
+                oldTopCard.Opacity = StackDepth > 0 ? 1 : 0;
+                if (StackDepth > 0)
+                    oldTopCard.TranslationY = ComputeStackTranslationY(oldTopCard, BackCardScale, StackOffset);
                 oldTopCard.BatchCommit();
             }
             finally
@@ -1159,6 +1440,7 @@ public class SwipeCardView : ContentView, IDisposable
             newTopCard.BatchBegin();
             newTopCard.BindingContext = previousItem;
             newTopCard.Scale = 1.0;
+            newTopCard.AnchorY = 0.5;
             newTopCard.Rotation = 0;
             newTopCard.TranslationX = 0;
             newTopCard.TranslationY = -newTopCard.Y;
@@ -1167,10 +1449,13 @@ public class SwipeCardView : ContentView, IDisposable
             newTopCard.IsVisible = true;
             newTopCard.BatchCommit();
 
-            // Hide the old top card
+            // Position the old top card as the back card
             oldTopCard.BatchBegin();
-            oldTopCard.Scale = 1.0;
-            oldTopCard.Opacity = 0;
+            oldTopCard.AnchorY = 0.5;
+            oldTopCard.Scale = StackDepth > 0 ? (double)BackCardScale : 1.0;
+            oldTopCard.Opacity = StackDepth > 0 ? 1 : 0;
+            if (StackDepth > 0)
+                oldTopCard.TranslationY = ComputeStackTranslationY(oldTopCard, BackCardScale, StackOffset);
             oldTopCard.BatchCommit();
         }
 
@@ -1183,6 +1468,8 @@ public class SwipeCardView : ContentView, IDisposable
         _itemIndex = _currentDisplayIndex + 2;
         TopItem = previousItem;
         PreviousItem = _currentDisplayIndex >= 1 ? ItemsSource[_currentDisplayIndex - 1] : null;
+
+        ResetShadowCards();
 
         // Force layout recalculation
         try


### PR DESCRIPTION
## Summary

Implements the card stack visual effect requested in #9. Adds three new BindableProperty values that let consumers show stacked cards behind the top card, creating the illusion of a deck.

## New Properties

| Property | Type | Default | Description |
|----------|------|---------|-------------|
| `StackDepth` | `int` | `0` | Number of cards visible behind the top card. 0 = off (backward compatible) |
| `StackOffset` | `double` | `10` | Vertical offset (dp) between each stacked card |
| `StackScaleStep` | `double` | `0.03` | Scale reduction per successive shadow card |

## How It Works

- **StackDepth=0**: No change — fully backward compatible
- **StackDepth=1**: The back card is visible at rest (shown with `BackCardScale` scale and `StackOffset` dp peek below the top card)
- **StackDepth=2+**: Additional decorative `Border` elements (shadow cards) appear below the real cards

The implementation uses center-anchored scaling with height-based compensation:
`TranslationY = -card.Y + peekAmount + height * (1 - scale) / 2`

This counteracts the way `AnchorY=0.5` scaling retracts the bottom edge, ensuring the back card's bottom edge peeks exactly `StackOffset` dp below the top card.

A `SizeChanged` fallback handles the timing issue where card and container heights are 0 during initial `Setup()`.

## Bug Fixes

- **Memory leak**: Shadow card `Border` elements now disposed in `Dispose()`
- **Event handler leak**: `SizeChanged` handler unsubscribed in `Dispose()`
- **CS8602 warning**: Added null check for `ItemsSource` before `.Count` access
- **Doc correction**: `StackScaleStep` XML doc said default was 0.04 (actual: 0.03)

## Usage

```xml
<swipeCardView:SwipeCardView
    ItemsSource="{Binding Profiles}"
    StackDepth="2"
    StackOffset="15"
    BackCardScale="0.95" />
```

## Testing

- ✅ 35 unit tests pass
- ✅ Build succeeds with 0 warnings (all TFMs)
- ✅ Verified on Android emulator (API 36): stack peek visible, swipe transitions smooth, GoBack works correctly
- ✅ Multi-model code review completed (Claude Sonnet 4.5 + GPT 5.1)
- ✅ Backward compatibility verified: StackDepth=0 pages (Simple, Colors, Border) work unchanged

## Version

Bumped to **1.1.0** (new feature with new public API surface).

Closes #9