### PR TITLE
fix: Colors page rounded corners and Tinder back arrow visibility

### DIFF
--- a/samples/SwipeCardView.Sample/Views/ColorsPage.xaml
+++ b/samples/SwipeCardView.Sample/Views/ColorsPage.xaml
@@ -21,7 +21,7 @@
                     <Border StrokeShape="RoundRectangle 20"
                             Stroke="Transparent"
                             StrokeThickness="0"
-                            BackgroundColor="#F8F8F8"
+                            BackgroundColor="Beige"
                             Padding="0"
                             InputTransparent="True">
                         <Border.Shadow>

--- a/samples/SwipeCardView.Sample/Views/ColorsPage.xaml.cs
+++ b/samples/SwipeCardView.Sample/Views/ColorsPage.xaml.cs
@@ -15,7 +15,9 @@ public partial class ColorsPage : ContentPage
 
     private void OnDragging(object sender, DraggingCardEventArgs e)
     {
-        var view = (View)sender;
+        // Use the card view (the Border with rounded corners) for color feedback,
+        // not the SwipeCardView itself which is a rectangular container.
+        var card = e.CardView ?? (View)sender;
 
         // Update page-level labels (not inside card template) to avoid
         // layout recalculation inside the Frame during Scale transforms,
@@ -29,36 +31,36 @@ public partial class ColorsPage : ContentPage
                 break;
 
             case DraggingCardPosition.UnderThreshold:
-                view.BackgroundColor = Colors.DarkTurquoise;
+                card.BackgroundColor = Colors.DarkTurquoise;
                 break;
 
             case DraggingCardPosition.OverThreshold:
                 switch (e.Direction)
                 {
                     case SwipeCardDirection.Left:
-                        view.BackgroundColor = Color.FromArgb("#FF6A4F");
+                        card.BackgroundColor = Color.FromArgb("#FF6A4F");
                         break;
 
                     case SwipeCardDirection.Right:
-                        view.BackgroundColor = Color.FromArgb("#63DD99");
+                        card.BackgroundColor = Color.FromArgb("#63DD99");
                         break;
 
                     case SwipeCardDirection.Up:
-                        view.BackgroundColor = Color.FromArgb("#2196F3");
+                        card.BackgroundColor = Color.FromArgb("#2196F3");
                         break;
 
                     case SwipeCardDirection.Down:
-                        view.BackgroundColor = Colors.MediumPurple;
+                        card.BackgroundColor = Colors.MediumPurple;
                         break;
                 }
                 break;
 
             case DraggingCardPosition.FinishedUnderThreshold:
-                view.BackgroundColor = Colors.Beige;
+                card.BackgroundColor = Colors.Beige;
                 break;
 
             case DraggingCardPosition.FinishedOverThreshold:
-                view.BackgroundColor = Colors.Beige;
+                card.BackgroundColor = Colors.Beige;
                 DirectionLabel.Text = string.Empty;
                 PositionLabel.Text = string.Empty;
                 break;

--- a/samples/SwipeCardView.Sample/Views/TinderPage.xaml
+++ b/samples/SwipeCardView.Sample/Views/TinderPage.xaml
@@ -6,6 +6,7 @@
              BackgroundColor="White"
              Shell.BackgroundColor="White"
              Shell.TitleColor="#333333"
+             Shell.ForegroundColor="#333333"
              Title ="Tinder">
 
     <Grid RowDefinitions="*,Auto" Padding="0">


### PR DESCRIPTION
## Summary

Fixes two sample app UI bugs:

### 1. Colors page: Sharp-cornered color feedback
The drag color feedback was applied to the \SwipeCardView\ container (rectangular) instead of the card's \Border\ (rounded corners). This caused the colored background to appear with 90° corners behind the card during drag.

**Fix:** Use \.CardView\ (the card Border with rounded corners) instead of \sender\ (the SwipeCardView) for background color changes.

### 2. Tinder page: Invisible back arrow
The Shell navigation back arrow was invisible on the white toolbar because \Shell.ForegroundColor\ wasn't set.

**Fix:** Add \Shell.ForegroundColor=\"#333333\"\ to make the arrow visible.

### Before / After

| Issue | Before | After |
|-------|--------|-------|
| Colors drag | Sharp 90° color rectangle behind card | Color fills the rounded card Border |
| Tinder arrow | Invisible on white background | Dark arrow visible |

Both are **sample app bugs**, not control bugs.